### PR TITLE
add sudo to make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 
 # Install the CLI to /usr/local/bin
 install: build
-	cp bin/rocketship /usr/local/bin/
+	sudo cp bin/rocketship /usr/local/bin/
 
 compose-up:
 	@if ! command -v docker-compose &> /dev/null; then \


### PR DESCRIPTION
This pull request includes a minor update to the `Makefile` to ensure the correct permissions are used when installing the CLI.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L26-R26): Updated the `install` target to use `sudo` when copying the `rocketship` binary to `/usr/local/bin/` to ensure the command has the necessary permissions.