### PR TITLE
Better CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,27 +36,43 @@ It combines a declarative YAML spec, Temporal‑style durable execution, and an 
 ## 🟢 5‑Minute Quick Start
 
 ```bash
-# 1. Install Prerequisites
+# 1. Install Prerequisites & CLI
 # macOS
-brew install go temporal
+brew install go temporal && go install github.com/rocketship-ai/rocketship/cmd/cli@latest
 
 # Linux
-curl -sSf https://temporal.download/cli.sh | sh
-# Install Go 1.24+ from https://go.dev/dl/
+curl -sSf https://temporal.download/cli.sh | sh && \
+  # Install Go 1.24+ from https://go.dev/dl/
+  go install github.com/rocketship-ai/rocketship/cmd/cli@latest
 
-# 2. Install Rocketship
-git clone https://github.com/rocketship-ai/rocketship.git
-cd rocketship
-make install
-
-# 3. Start the Local Server (in terminal 1)
+# 2. Start the Local Server (in terminal 1)
 rocketship start server --local
 
-# 4. Create a Session (in terminal 2)
+# 3. Create a Session (in terminal 2)
 rocketship start session --engine localhost:7700
 
-# 5. Run Example Test
-rocketship run --file examples/simple-delay/rocketship.yaml
+# 4. Create a Test File
+cat > simple-test.yaml << 'EOF'
+name: "Simple Delay Test Suite"
+description: "A simple test suite that demonstrates delays"
+version: "v1.0.0"
+tests:
+  - name: "Test 1"
+    steps:
+      - name: "Wait for 5 seconds"
+        plugin: "delay"
+        config:
+          duration: "5s"
+  - name: "Test 2"
+    steps:
+      - name: "Wait for 10 seconds"
+        plugin: "delay"
+        config:
+          duration: "10s"
+EOF
+
+# 5. Run the Test
+rocketship run --file simple-test.yaml
 ```
 
 You should see output like:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ![Under Construction](docs/misc/assets/under-construction-banner.png)
 
-### 🚀 **Rocketship** – AI‑Native End‑to‑End Testing for Cloud‑Native Systems
+### 🚀 **Rocketship** – AI‑Native End‑to‑End Testing
 
 Rocketship is an **open‑source, AI‑powered platform** that verifies complex, event‑driven micro‑services the same way you reason about them: as real‑world **workflows** that span queues, APIs, databases, and file buckets.  
-It combines a declarative YAML spec, Temporal‑style durable execution, and an LLM “Test‑Copilot” that keeps your tests in sync with every code change—whether written by humans or autonomous agents.
+It combines a declarative YAML spec, Temporal‑style durable execution, and an LLM "Test‑Copilot" that keeps your tests in sync with every code change—whether written by humans or autonomous agents.
 
 ---
 
@@ -17,7 +17,7 @@ It combines a declarative YAML spec, Temporal‑style durable execution, and an 
 | **2. Test drift**                | Code changes faster than tests; flakiness grows. Tests become outdated.               | **LLM Diff‑Copilot** scans your PR diff → proposes YAML patch; optional auto‑merge.                          |
 | **3. CI headaches**              | Full E2E env is heavy, slow, and flaky.                                               | Temporal‑based runner spins timers & retries _without_ holding CI pods; run in your cluster or local Docker. |
 | **4. Security / data residency** | SaaS testing tools require exposing internal endpoints.                               | Tests execute in **Rocketship Agent** pods that are part of your infra—only test metadata leaves the VPC.    |
-| **5. AI agent deploy risk**      | Agents can commit code 24/7; unsafe merges land in prod.                              | Agents call Rocketship’s MCP/gRPC API → must get green tests before `git push`.                              |
+| **5. AI agent deploy risk**      | Agents can commit code 24/7; unsafe merges land in prod.                              | Agents call Rocketship's MCP/gRPC API → must get green tests before `git push`.                              |
 
 ---
 
@@ -27,28 +27,45 @@ It combines a declarative YAML spec, Temporal‑style durable execution, and an 
 - **Plugin & Connector SDK** – Drop‑in Go package; implement one Activity function and a JSON schema to add Azure, GCP, or custom infra.
 - **Temporal‑powered Engine** – Durable workflows, back‑offs, and long timers without hogging threads.
 - **AI Diff‑Copilot** – `rocketship suggest --diff HEAD~1` emits a ready‑to‑commit patch that updates or adds tests.
-- **Local‑first / K8s‑native** – `rocketship start` spins Temporal + Engine + Agent + LocalStack via Docker Compose (or Helm in minikube).
+- **Local‑first / K8s‑native** – `rocketship start` spins Temporal + Engine + Agent + LocalStack via Docker Compose (or Helm in minikube).
 - **CI Plugins** – Buildkite Orb and GitHub Action sample provided.
 - **MCP Server Mode** _(opt‑in)_ – Expose Rocketship as a [Model Context Protocol](https://mcp.dev) capability so any LLM agent can invoke `runTest`, `listTests`, or `generateTests`.
 
 ---
 
-## 🟢 5‑Minute Quick Start
+## 🟢 5‑Minute Quick Start
 
 ```bash
-# 1.  Install CLI
-go install github.com/rocketship/rocketship/cmd/rocketship@latest
+# 1. Install Prerequisites
+# macOS
+brew install go temporal
 
-# 2.  Bootstrap local stack (Temporal, Agent, LocalStack)
-rocketship start
+# Linux
+curl -sSf https://temporal.download/cli.sh | sh
+# Install Go 1.24+ from https://go.dev/dl/
 
-# 3.  Init sample test
-rocketship init --example order-workflow
-cat rocketship.yaml           # peek at the spec
+# 2. Install Rocketship
+git clone https://github.com/rocketship-ai/rocketship.git
+cd rocketship
+make install
 
-# 4.  Run end‑to‑end test
-rocketship run
+# 3. Start the Local Server (in terminal 1)
+rocketship start server --local
 
-# 5.  Watch logs / status
-rocketship logs $(rocketship status --latest)
+# 4. Create a Session (in terminal 2)
+rocketship start session --engine localhost:7700
+
+# 5. Run Example Test
+rocketship run --file examples/simple-delay/rocketship.yaml
+```
+
+You should see output like:
+
+```
+Starting test run "Simple Delay Test Suite"... 🚀
+Running test: "Test 1"...
+Running test: "Test 2"...
+Test: "Test 1" passed
+Test: "Test 2" passed
+Test run: "Simple Delay Test Suite" finished. All 2 tests passed.
 ```

--- a/internal/api/generated/engine.pb.go
+++ b/internal/api/generated/engine.pb.go
@@ -157,6 +157,8 @@ type LogLine struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Ts            string                 `protobuf:"bytes,1,opt,name=ts,proto3" json:"ts,omitempty"`
 	Msg           string                 `protobuf:"bytes,2,opt,name=msg,proto3" json:"msg,omitempty"`
+	Color         string                 `protobuf:"bytes,3,opt,name=color,proto3" json:"color,omitempty"` // "green" | "red" | "purple" | "" (default)
+	Bold          bool                   `protobuf:"varint,4,opt,name=bold,proto3" json:"bold,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -203,6 +205,20 @@ func (x *LogLine) GetMsg() string {
 		return x.Msg
 	}
 	return ""
+}
+
+func (x *LogLine) GetColor() string {
+	if x != nil {
+		return x.Color
+	}
+	return ""
+}
+
+func (x *LogLine) GetBold() bool {
+	if x != nil {
+		return x.Bold
+	}
+	return false
 }
 
 type ListRunsRequest struct {
@@ -363,10 +379,12 @@ const file_engine_proto_rawDesc = "" +
 	"\x11CreateRunResponse\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\")\n" +
 	"\x10LogStreamRequest\x12\x15\n" +
-	"\x06run_id\x18\x01 \x01(\tR\x05runId\"+\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\"U\n" +
 	"\aLogLine\x12\x0e\n" +
 	"\x02ts\x18\x01 \x01(\tR\x02ts\x12\x10\n" +
-	"\x03msg\x18\x02 \x01(\tR\x03msg\"\x11\n" +
+	"\x03msg\x18\x02 \x01(\tR\x03msg\x12\x14\n" +
+	"\x05color\x18\x03 \x01(\tR\x05color\x12\x12\n" +
+	"\x04bold\x18\x04 \x01(\bR\x04bold\"\x11\n" +
 	"\x0fListRunsRequest\"A\n" +
 	"\x10ListRunsResponse\x12-\n" +
 	"\x04runs\x18\x01 \x03(\v2\x19.rocketship.v1.RunSummaryR\x04runs\"u\n" +

--- a/internal/cli/process_manager.go
+++ b/internal/cli/process_manager.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// processManager handles the lifecycle of child processes
+type processManager struct {
+	processes []*exec.Cmd
+	mu        sync.Mutex
+}
+
+func newProcessManager() *processManager {
+	return &processManager{
+		processes: make([]*exec.Cmd, 0),
+	}
+}
+
+func (pm *processManager) Add(cmd *exec.Cmd) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.processes = append(pm.processes, cmd)
+}
+
+func (pm *processManager) Cleanup() {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	for _, proc := range pm.processes {
+		if proc != nil && proc.Process != nil {
+			// Send SIGTERM first for graceful shutdown
+			_ = proc.Process.Signal(syscall.SIGTERM)
+
+			// Give process time to shutdown gracefully
+			time.Sleep(2 * time.Second)
+
+			// Force kill if still running
+			_ = proc.Process.Kill()
+		}
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -91,7 +91,7 @@ func NewRunCmd() *cobra.Command {
 				return fmt.Errorf("failed to create run: %w", err)
 			}
 
-			fmt.Printf("%s\n", purple(fmt.Sprintf("Starting test run \"%s\"...", run.Name)))
+			fmt.Printf("%s\n", purple(fmt.Sprintf("🚀🚀🚀 Starting test run \"%s\"... 🚀🚀🚀", run.Name)))
 
 			// Stream logs
 			logStream, err := client.StreamLogs(ctx, runID)
@@ -102,18 +102,15 @@ func NewRunCmd() *cobra.Command {
 			for {
 				select {
 				case <-ctx.Done():
-					fmt.Printf("\n%s\n", purple(fmt.Sprintf("Test run \"%s\" has finished", run.Name)))
 					return nil
 				default:
 					log, err := logStream.Recv()
 					if err == io.EOF {
-						fmt.Printf("\n%s\n", purple(fmt.Sprintf("Test run \"%s\" has finished", run.Name)))
 						return nil
 					}
 					if err != nil {
 						// Check if the error is due to context cancellation
 						if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
-							fmt.Printf("\n%s\n", purple(fmt.Sprintf("Test run \"%s\" has finished", run.Name)))
 							return nil
 						}
 						return fmt.Errorf("error receiving log: %w", err)
@@ -122,9 +119,9 @@ func NewRunCmd() *cobra.Command {
 					if msg := log.Msg; len(msg) > 7 {
 						if msg[:7] == "Test: \"" {
 							if msg[len(msg)-6:] == "passed" {
-								fmt.Printf("%s\n", green(fmt.Sprintf("[%s] %s", log.Ts, msg)))
+								fmt.Printf("%s\n", green(fmt.Sprintf("[%s] %s ✅", log.Ts, msg)))
 							} else if msg[len(msg)-6:] == "failed" {
-								fmt.Printf("%s\n", red(fmt.Sprintf("[%s] %s", log.Ts, msg)))
+								fmt.Printf("%s\n", red(fmt.Sprintf("[%s] %s ❌", log.Ts, msg)))
 							} else {
 								fmt.Printf("[%s] %s\n", log.Ts, msg)
 							}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1,7 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,6 +19,42 @@ import (
 func NewStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
+		Short: "Start rocketship components",
+		Long:  `Start rocketship components like the server or create a new session.`,
+	}
+
+	cmd.AddCommand(newStartServerCmd())
+	cmd.AddCommand(newStartSessionCmd())
+
+	return cmd
+}
+
+func newStartServerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Start the rocketship server",
+		Long:  `Start the rocketship server either locally or connect to a remote instance.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			isLocal, err := cmd.Flags().GetBool("local")
+			if err != nil {
+				return err
+			}
+
+			if isLocal {
+				return setupLocalEnvironment()
+			}
+
+			return fmt.Errorf("remote server connection not yet implemented")
+		},
+	}
+
+	cmd.Flags().Bool("local", false, "Start local development environment")
+	return cmd
+}
+
+func newStartSessionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "session",
 		Short: "Start a new rocketship session",
 		Long:  `Start a new rocketship session by connecting to a rocketship engine.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -24,8 +67,6 @@ func NewStartCmd() *cobra.Command {
 				return fmt.Errorf("engine address is required")
 			}
 
-			// TODO: Validate connection to engine
-
 			session := &Session{
 				EngineAddress: engineAddr,
 				SessionID:     uuid.New().String(),
@@ -36,11 +77,89 @@ func NewStartCmd() *cobra.Command {
 				return fmt.Errorf("failed to save session: %w", err)
 			}
 
-			fmt.Printf("Session started successfully. Engine address: %s\n", engineAddr)
+			fmt.Printf("Session saved successfully. Engine address: %s\n", engineAddr)
 			return nil
 		},
 	}
 
 	cmd.Flags().String("engine", "", "Address of the rocketship engine (e.g., localhost:8080)")
 	return cmd
+}
+
+func setupLocalEnvironment() error {
+	// Create a context that we can cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Set up process manager
+	pm := newProcessManager()
+	defer pm.Cleanup()
+
+	// Set up signal handling
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		log.Println("\nShutting down local environment...")
+		cancel()
+		pm.Cleanup()
+		os.Exit(0)
+	}()
+
+	// Start Temporal server
+	log.Println("Starting Temporal server...")
+	temporalCmd := exec.CommandContext(ctx, "temporal", "server", "start-dev")
+	temporalCmd.Stderr = os.Stderr
+	temporalCmd.Stdout = os.Stdout
+	if err := temporalCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start temporal server: %w", err)
+	}
+	pm.Add(temporalCmd)
+
+	// Give Temporal a moment to start
+	time.Sleep(5 * time.Second)
+
+	// Set environment variables for worker and engine
+	if err := os.Setenv("TEMPORAL_HOST", "localhost:7233"); err != nil {
+		return fmt.Errorf("failed to set TEMPORAL_HOST environment variable: %w", err)
+	}
+
+	// Start the worker
+	log.Println("Starting Rocketship worker...")
+	workerPath := filepath.Join("cmd", "worker", "main.go")
+	workerCmd := exec.CommandContext(ctx, "go", "run", workerPath)
+	workerCmd.Stderr = os.Stderr
+	workerCmd.Stdout = os.Stdout
+	if err := workerCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start worker: %w", err)
+	}
+	pm.Add(workerCmd)
+
+	// Start the engine
+	log.Println("Starting Rocketship engine...")
+	enginePath := filepath.Join("cmd", "engine", "main.go")
+	engineCmd := exec.CommandContext(ctx, "go", "run", enginePath)
+	engineCmd.Stderr = os.Stderr
+	engineCmd.Stdout = os.Stdout
+	if err := engineCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start engine: %w", err)
+	}
+	pm.Add(engineCmd)
+
+	// Save local session
+	session := &Session{
+		EngineAddress: "localhost:7700",
+		SessionID:     uuid.New().String(),
+		CreatedAt:     time.Now(),
+	}
+
+	if err := SaveSession(session); err != nil {
+		return fmt.Errorf("failed to save session: %w", err)
+	}
+
+	log.Println("Local development environment is ready! 🚀")
+
+	// Keep the parent process running until context is cancelled
+	<-ctx.Done()
+	return ctx.Err()
 }

--- a/internal/orchestrator/engine.go
+++ b/internal/orchestrator/engine.go
@@ -6,38 +6,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"sync"
 	"time"
 
 	"github.com/rocketship-ai/rocketship/internal/api/generated"
 	"github.com/rocketship-ai/rocketship/internal/dsl"
 	"go.temporal.io/sdk/client"
 )
-
-type Engine struct {
-	generated.UnimplementedEngineServer
-	temporal client.Client
-	runs     map[string]*RunInfo
-	mu       sync.RWMutex
-}
-type RunInfo struct {
-	ID        string
-	Name      string
-	Status    string
-	StartedAt time.Time
-	EndedAt   time.Time
-	Tests     map[string]*TestInfo // Test's WorkflowID : TestInfo
-	Logs      []string
-}
-
-type TestInfo struct {
-	WorkflowID string
-	Name       string
-	Status     string
-	StartedAt  time.Time
-	EndedAt    time.Time
-	RunID      string
-}
 
 func NewEngine(c client.Client) *Engine {
 	return &Engine{

--- a/internal/orchestrator/engine.go
+++ b/internal/orchestrator/engine.go
@@ -44,7 +44,7 @@ func (e *Engine) CreateRun(ctx context.Context, req *generated.CreateRunRequest)
 		Tests:     make(map[string]*TestInfo),
 		Logs: []LogLine{
 			{
-				Msg:   fmt.Sprintf("🚀🚀🚀 Starting test run \"%s\"... 🚀🚀🚀", run.Name),
+				Msg:   fmt.Sprintf("Starting test run \"%s\"... 🚀", run.Name),
 				Color: "purple",
 				Bold:  true,
 			},
@@ -78,6 +78,12 @@ func (e *Engine) CreateRun(ctx context.Context, req *generated.CreateRunRequest)
 
 		e.mu.Lock()
 		runInfo.Tests[testID] = testInfo
+		// add a log line for the start of the test
+		runInfo.Logs = append(runInfo.Logs, LogLine{
+			Msg:   fmt.Sprintf("Running test: \"%s\"...", test.Name),
+			Color: "n/a",
+			Bold:  false,
+		})
 		e.mu.Unlock()
 
 		go e.monitorWorkflow(runID, execution.GetID(), execution.GetRunID())

--- a/internal/orchestrator/engine.go
+++ b/internal/orchestrator/engine.go
@@ -222,13 +222,13 @@ func (e *Engine) monitorWorkflow(runID, workflowID, workflowRunID string) {
 			e.addLog(runID, fmt.Sprintf("Test: \"%s\" passed", testName))
 		}
 	case <-ctx.Done():
-		log.Printf("[DEBUG] Monitoring timed out for run %s", runID)
+		log.Printf("[DEBUG] Monitoring timed out for test ID %s", workflowID)
 		e.mu.Lock()
 		if runInfo, exists := e.runs[runID]; exists {
-			runInfo.Status = "TIMEOUT"
-			runInfo.EndedAt = time.Now()
+			runInfo.Tests[workflowID].Status = "TIMEOUT"
+			runInfo.Tests[workflowID].EndedAt = time.Now()
 			e.mu.Unlock()
-			e.addLog(runID, "Test monitoring timed out")
+			e.addLog(runID, fmt.Sprintf("Test: \"%s\" timed out", runInfo.Tests[workflowID].Name))
 		} else {
 			e.mu.Unlock()
 		}

--- a/internal/orchestrator/engine_test.go
+++ b/internal/orchestrator/engine_test.go
@@ -86,17 +86,17 @@ func TestAddLog(t *testing.T) {
 	runInfo := &RunInfo{
 		ID:     "test-run-id",
 		Status: "RUNNING",
-		Logs:   []string{},
+		Logs:   []LogLine{},
 	}
 	engine.runs["test-run-id"] = runInfo
 
-	engine.addLog("test-run-id", "Test log message")
+	engine.addLog("test-run-id", "Test log message", "green", true)
 
 	if len(runInfo.Logs) != 1 {
 		t.Fatalf("Expected 1 log message, got %d", len(runInfo.Logs))
 	}
 
-	if runInfo.Logs[0] != "Test log message" {
-		t.Errorf("Expected log message 'Test log message', got '%s'", runInfo.Logs[0])
+	if runInfo.Logs[0].Msg != "Test log message" {
+		t.Errorf("Expected log message 'Test log message', got '%s'", runInfo.Logs[0].Msg)
 	}
 }

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -1,0 +1,34 @@
+package orchestrator
+
+import (
+	"sync"
+	"time"
+
+	"github.com/rocketship-ai/rocketship/internal/api/generated"
+	"go.temporal.io/sdk/client"
+)
+
+type Engine struct {
+	generated.UnimplementedEngineServer
+	temporal client.Client
+	runs     map[string]*RunInfo
+	mu       sync.RWMutex
+}
+type RunInfo struct {
+	ID        string
+	Name      string
+	Status    string
+	StartedAt time.Time
+	EndedAt   time.Time
+	Tests     map[string]*TestInfo // Test's WorkflowID : TestInfo
+	Logs      []string
+}
+
+type TestInfo struct {
+	WorkflowID string
+	Name       string
+	Status     string
+	StartedAt  time.Time
+	EndedAt    time.Time
+	RunID      string
+}

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -21,7 +21,13 @@ type RunInfo struct {
 	StartedAt time.Time
 	EndedAt   time.Time
 	Tests     map[string]*TestInfo // Test's WorkflowID : TestInfo
-	Logs      []string
+	Logs      []LogLine
+}
+
+type LogLine struct {
+	Msg   string
+	Color string
+	Bold  bool
 }
 
 type TestInfo struct {

--- a/proto/engine.proto
+++ b/proto/engine.proto
@@ -18,7 +18,12 @@ message CreateRunResponse {
 }
 
 message LogStreamRequest { string run_id = 1; }
-message LogLine         { string ts = 1; string msg = 2; }
+message LogLine {
+  string ts = 1;
+  string msg = 2;
+  string color = 3;  // "green" | "red" | "purple" | "" (default)
+  bool bold = 4;
+}
 
 message ListRunsRequest {}
 message ListRunsResponse { repeated RunSummary runs = 1; }


### PR DESCRIPTION
This pull request introduces several enhancements and refinements to the Rocketship project, focusing on improving the CLI, orchestrator, and documentation. Key changes include the addition of a process manager for managing child processes, enhancements to the log streaming system with metadata support, and a revamped quick start guide in the documentation. These updates aim to improve usability, maintainability, and clarity.

### CLI Enhancements:
* Added a `processManager` in `internal/cli/process_manager.go` to handle the lifecycle of child processes, ensuring proper cleanup during shutdown.
* Introduced new subcommands (`server` and `session`) under `rocketship start` for better organization and functionality, including the ability to set up a local development environment. [[1]](diffhunk://#diff-7a6c7b69235cfd1928f72edb7f262f46a0bec09b7308635f82ffe3b0723feb08R22-R57) [[2]](diffhunk://#diff-7a6c7b69235cfd1928f72edb7f262f46a0bec09b7308635f82ffe3b0723feb08L39-R165)
* Removed signal handling from `run` command and refactored log styling to dynamically apply color and boldness based on metadata. [[1]](diffhunk://#diff-30f30550c03f971732cfeb7b92d7d64e64447acf969bfa5a55832429cf18cd01L8-L10) [[2]](diffhunk://#diff-30f30550c03f971732cfeb7b92d7d64e64447acf969bfa5a55832429cf18cd01L105-R116)

### Orchestrator Improvements:
* Enhanced log streaming in `internal/orchestrator/engine.go` to include metadata such as color and boldness, improving log readability in the CLI. [[1]](diffhunk://#diff-1fb45ca6d67d75f14a93439d29e0943f0aee87b07751c0aba7355f23c5837114L71-R51) [[2]](diffhunk://#diff-1fb45ca6d67d75f14a93439d29e0943f0aee87b07751c0aba7355f23c5837114L127-R122)
* Refactored the `monitorWorkflow` method to add detailed logs for test status updates (e.g., "passed," "failed," or "timed out") with appropriate styling.

### Documentation Updates:
* Updated the README to simplify the quick start guide, replacing the old CLI installation and test initialization steps with a more detailed and user-friendly process.
* Minor formatting adjustments in the README for consistency, such as replacing typographic quotes with standard quotes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20)