### PR TITLE
chore: add release pipeline for CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - "v*" # Trigger on version tags
+
+permissions:
+  contents: write # Needed for creating releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          check-latest: true
+
+      - name: Run tests
+        run: make test
+
+      - name: Build binaries
+        run: |
+          make build-binaries
+          make build
+          # Create release artifacts for different platforms
+          GOOS=darwin GOARCH=amd64 go build -o bin/rocketship-darwin-amd64 cmd/rocketship/main.go
+          GOOS=darwin GOARCH=arm64 go build -o bin/rocketship-darwin-arm64 cmd/rocketship/main.go
+          GOOS=linux GOARCH=amd64 go build -o bin/rocketship-linux-amd64 cmd/rocketship/main.go
+          GOOS=linux GOARCH=arm64 go build -o bin/rocketship-linux-arm64 cmd/rocketship/main.go
+          GOOS=windows GOARCH=amd64 go build -o bin/rocketship-windows-amd64.exe cmd/rocketship/main.go
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            bin/rocketship-darwin-amd64
+            bin/rocketship-darwin-arm64
+            bin/rocketship-linux-amd64
+            bin/rocketship-linux-arm64
+            bin/rocketship-windows-amd64.exe
+          draft: false
+          prerelease: false
+          generate_release_notes: true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check if a version was provided
+if [ -z "$1" ]; then
+    echo "Error: No version tag provided"
+    echo "Usage: $0 <version>"
+    echo "Example: $0 v0.1.0"
+    exit 1
+fi
+
+VERSION=$1
+
+# Validate version format
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in the format v0.0.0"
+    echo "Example: v0.1.0"
+    exit 1
+fi
+
+# Check if we're in the root directory
+if [ ! -f "go.mod" ]; then
+    echo "Error: Must be run from repository root"
+    exit 1
+fi
+
+# Create and push the tag
+echo "Creating tag $VERSION..."
+git tag -a $VERSION -m "Release $VERSION"
+git push origin $VERSION
+
+echo "Tag $VERSION created and pushed!"
+echo "GitHub Actions will now build and create the release."
+echo "You can monitor the progress at: https://github.com/rocketship-ai/rocketship/actions" 


### PR DESCRIPTION
This pull request introduces a new release workflow for the project, automating the process of building, testing, and creating release artifacts for multiple platforms. It also includes a script to streamline tagging and triggering the release process. Below are the key changes:

### GitHub Actions Workflow for Releases:
* Added a new GitHub Actions workflow in `.github/workflows/release.yml` to automate the release process. This workflow triggers on version tags, runs tests, builds binaries for multiple platforms (e.g., macOS, Linux, Windows), and creates a GitHub release with the generated artifacts.

### Release Script:
* Added a `scripts/release.sh` script to simplify the creation of version tags. The script validates the version format, ensures it is run from the repository root, creates an annotated Git tag, and pushes it to trigger the release workflow.