### PR TITLE
fix: update release workflow and gitignore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,20 @@ jobs:
           go-version: "1.24"
           check-latest: true
 
+      - name: Build embedded binaries
+        run: |
+          # Create necessary directories
+          mkdir -p internal/embedded/bin
+
+          # Build worker and engine binaries first
+          go build -o internal/embedded/bin/worker cmd/worker/main.go
+          go build -o internal/embedded/bin/engine cmd/engine/main.go
+
       - name: Run tests
         run: make test
 
-      - name: Build binaries
+      - name: Build release artifacts
         run: |
-          make build-binaries
-          make build
           # Create release artifacts for different platforms
           GOOS=darwin GOARCH=amd64 go build -o bin/rocketship-darwin-amd64 cmd/rocketship/main.go
           GOOS=darwin GOARCH=arm64 go build -o bin/rocketship-darwin-arm64 cmd/rocketship/main.go

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
-bin
+/bin/
+/internal/embedded/bin/*
+!/internal/embedded/bin/.gitkeep

--- a/for-maintainers/setup-hooks.sh
+++ b/for-maintainers/setup-hooks.sh
@@ -17,4 +17,10 @@ EOL
 # Make it executable
 chmod +x .git/hooks/pre-commit
 
-echo "✅ Pre-commit hook installed successfully!" 
+echo "✅ Pre-commit hook installed successfully!"
+
+# Run initial dev setup if not already done
+if [ ! -f "internal/embedded/bin/engine" ] || [ ! -f "internal/embedded/bin/worker" ]; then
+    echo "Running initial development setup..."
+    make build-binaries
+fi 


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to enhance the build process by separating the creation of embedded binaries and improving the naming and structure of build steps.

### Workflow improvements:

* Added a new step to build embedded binaries (`worker` and `engine`) and store them in the `internal/embedded/bin` directory. This ensures these binaries are built before running tests.
* Renamed the "Build binaries" step to "Build release artifacts" for better clarity and updated the step to focus on creating platform-specific release artifacts.