### PR TITLE
Fix exec for other machines

### DIFF
--- a/for-contributors/RELEASING.md
+++ b/for-contributors/RELEASING.md
@@ -47,7 +47,19 @@ This document describes the process for developing and releasing new versions of
 
 ## Release Process
 
-1. **Create a Release**
+1. **Update Default Version**
+
+   Before creating a release, update the default version in `internal/embedded/binaries.go`:
+
+   ```bash
+   # Example: For releasing v1.2.3
+   sed -i '' 's/defaultVersion *= *".*"/defaultVersion = "v1.2.3"/' internal/embedded/binaries.go
+   git add internal/embedded/binaries.go
+   git commit -m "chore: update default version to v1.2.3"
+   git push
+   ```
+
+2. **Create a Release**
 
    Once changes are merged to main, a maintainer can create a new release:
 
@@ -64,7 +76,7 @@ This document describes the process for developing and releasing new versions of
    - Build platform-specific binaries
    - Attach binaries to the release
 
-2. **Test Installation**
+3. **Test Installation**
 
    ```bash
    # Install released version

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -146,17 +146,6 @@ func setupLocalEnvironment() error {
 	}
 	pm.Add(engineCmd)
 
-	// Save local session
-	session := &Session{
-		EngineAddress: "localhost:7700",
-		SessionID:     uuid.New().String(),
-		CreatedAt:     time.Now(),
-	}
-
-	if err := SaveSession(session); err != nil {
-		return fmt.Errorf("failed to save session: %w", err)
-	}
-
 	log.Println("Local development environment is ready! 🚀")
 
 	// Keep the parent process running until context is cancelled

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
+	defaultVersion   = "v0.1.5" // This should be updated with each release
 )
 
 // ExtractAndRun extracts a binary and runs it
@@ -27,10 +28,10 @@ func ExtractAndRun(name string, args []string, env []string) (*exec.Cmd, error) 
 		return cmd, nil
 	}
 
-	// Get the tag from environment, fallback to latest
+	// Get the tag from environment, fallback to default version
 	tag := os.Getenv("ROCKETSHIP_VERSION")
 	if tag == "" {
-		tag = "latest"
+		tag = defaultVersion
 	}
 
 	// Get the temporary directory

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -1,6 +1,7 @@
 package embedded
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,8 +13,12 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	defaultVersion   = "v0.1.5" // This should be updated with each release
+	defaultVersion   = "v0.1.6" // This should be updated with each release
 )
+
+type binaryMetadata struct {
+	Version string `json:"version"`
+}
 
 // ExtractAndRun extracts a binary and runs it
 func ExtractAndRun(name string, args []string, env []string) (*exec.Cmd, error) {
@@ -46,13 +51,15 @@ func ExtractAndRun(name string, args []string, env []string) (*exec.Cmd, error) 
 		return nil, fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	// Path to the extracted binary
+	// Path to the extracted binary and its metadata
 	binaryPath := filepath.Join(rocketshipDir, name)
+	metadataPath := binaryPath + ".json"
 
 	// Check if we need to extract the binary
 	needsExtract := true
-	if stat, err := os.Stat(binaryPath); err == nil {
-		if stat.Mode()&0111 != 0 { // Check if executable
+	if stat, err := os.Stat(binaryPath); err == nil && stat.Mode()&0111 != 0 {
+		// Binary exists and is executable, check version
+		if metadata, err := loadMetadata(metadataPath); err == nil && metadata.Version == tag {
 			needsExtract = false
 		}
 	}
@@ -96,6 +103,11 @@ func ExtractAndRun(name string, args []string, env []string) (*exec.Cmd, error) 
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to close binary file: %w", closeErr)
 		}
+
+		// Save metadata
+		if err := saveMetadata(metadataPath, tag); err != nil {
+			return nil, fmt.Errorf("failed to save binary metadata: %w", err)
+		}
 	}
 
 	// Create the command
@@ -105,4 +117,31 @@ func ExtractAndRun(name string, args []string, env []string) (*exec.Cmd, error) 
 	cmd.Stderr = os.Stderr
 
 	return cmd, nil
+}
+
+func loadMetadata(path string) (*binaryMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata binaryMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, err
+	}
+
+	return &metadata, nil
+}
+
+func saveMetadata(path string, version string) error {
+	metadata := binaryMetadata{
+		Version: version,
+	}
+
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
 }


### PR DESCRIPTION
This pull request introduces changes to improve the release process, enhance binary versioning and metadata handling, and refine session management. The most significant updates include adding a default version for binaries, implementing metadata handling for binaries, and improving permission handling in session file operations.

### Release Process Improvements:
* Updated the release process documentation to include a step for updating the default binary version in `internal/embedded/binaries.go` before creating a release.
* Adjusted the numbering of steps in the release process to accommodate the new step.

### Binary Versioning and Metadata Enhancements:
* Introduced a `defaultVersion` constant in `internal/embedded/binaries.go` to serve as a fallback when the `ROCKETSHIP_VERSION` environment variable is not set. [[1]](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388R16-R22) [[2]](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L30-R39)
* Added metadata handling for binaries, including saving and loading version information to ensure the correct binary version is used. [[1]](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L48-R62) [[2]](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388R106-R110) [[3]](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388R121-R147)

### Session Management Refinements:
* Improved permission handling in `SaveSession` to ensure directories and session files are created with user-only write permissions, and added fallback logic to fix permissions if necessary.
* Removed the saving of local sessions from the `setupLocalEnvironment` function in `internal/cli/start.go`, simplifying the setup process.