### PR TITLE
Bump to v0.1.7

### DIFF
--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	defaultVersion   = "v0.1.6" // This should be updated with each release
+	defaultVersion   = "v0.1.7" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request includes a minor update to the `internal/embedded/binaries.go` file. The `defaultVersion` constant has been updated from `v0.1.6` to `v0.1.7` to reflect the latest release.