### PR TITLE
Bump CLI version to v0.1.9

### DIFF
--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	defaultVersion   = "v0.1.6" // This should be updated with each release
+	defaultVersion   = "v0.1.9" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request updates the default version of the Rocketship binary in the `internal/embedded/binaries.go` file to reflect the latest release.

Version update:

* Updated the `defaultVersion` constant from `"v0.1.6"` to `"v0.1.9"` to ensure the application uses the latest release of the Rocketship binary. (`[internal/embedded/binaries.goL16-R16](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L16-R16)`)