### PR TITLE
check in better http example

### DIFF
--- a/examples/simple-http/rocketship.yaml
+++ b/examples/simple-http/rocketship.yaml
@@ -4,6 +4,10 @@ version: "v1.0.0"
 tests:
   - name: "Get Users List"
     steps:
+      - name: "Delay Step"
+        plugin: "delay"
+        config:
+          duration: "5s"
       - name: "Get user list"
         plugin: "http"
         config:
@@ -20,6 +24,10 @@ tests:
 
   - name: "Get Single User"
     steps:
+      - name: "Delay Step"
+        plugin: "delay"
+        config:
+          duration: "5s"
       - name: "Get specific user"
         plugin: "http"
         config:
@@ -39,6 +47,10 @@ tests:
 
   - name: "Create New User"
     steps:
+      - name: "Delay Step"
+        plugin: "delay"
+        config:
+          duration: "5s"
       - name: "Create user"
         plugin: "http"
         config:
@@ -61,6 +73,10 @@ tests:
 
   - name: "Update User"
     steps:
+      - name: "Delay Step"
+        plugin: "delay"
+        config:
+          duration: "5s"
       - name: "Update user"
         plugin: "http"
         config:
@@ -86,6 +102,10 @@ tests:
 
   - name: "Delete User"
     steps:
+      - name: "Delay Step"
+        plugin: "delay"
+        config:
+          duration: "5s"
       - name: "Delete user"
         plugin: "http"
         config:


### PR DESCRIPTION
This pull request introduces a new "Delay Step" to all test cases in the `examples/simple-http/rocketship.yaml` file. The delay step uses the `delay` plugin to add a 5-second pause before executing the main HTTP-related steps in each test case.

Enhancements to test cases:

* Added a "Delay Step" with a 5-second duration to the `Get Users List` test case. (`examples/simple-http/rocketship.yaml`, [examples/simple-http/rocketship.yamlR7-R10](diffhunk://#diff-672ab6b5b127a926e5d4475af03e05b509d32fe6fe1c8312fea2c93a29f44800R7-R10))
* Added a "Delay Step" with a 5-second duration to the `Get Single User` test case. (`examples/simple-http/rocketship.yaml`, [examples/simple-http/rocketship.yamlR27-R30](diffhunk://#diff-672ab6b5b127a926e5d4475af03e05b509d32fe6fe1c8312fea2c93a29f44800R27-R30))
* Added a "Delay Step" with a 5-second duration to the `Create New User` test case. (`examples/simple-http/rocketship.yaml`, [examples/simple-http/rocketship.yamlR50-R53](diffhunk://#diff-672ab6b5b127a926e5d4475af03e05b509d32fe6fe1c8312fea2c93a29f44800R50-R53))
* Added a "Delay Step" with a 5-second duration to the `Update User` test case. (`examples/simple-http/rocketship.yaml`, [examples/simple-http/rocketship.yamlR76-R79](diffhunk://#diff-672ab6b5b127a926e5d4475af03e05b509d32fe6fe1c8312fea2c93a29f44800R76-R79))
* Added a "Delay Step" with a 5-second duration to the `Delete User` test case. (`examples/simple-http/rocketship.yaml`, [examples/simple-http/rocketship.yamlR105-R108](diffhunk://#diff-672ab6b5b127a926e5d4475af03e05b509d32fe6fe1c8312fea2c93a29f44800R105-R108))