### PR TITLE
Dockerize Rocketship CLI

### DIFF
--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -1,0 +1,43 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the rocketship CLI binary
+RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/rocketship ./cmd/rocketship
+
+# Create the final image
+FROM ubuntu:22.04
+
+# Install required packages and Temporal CLI
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    && curl -sSf https://temporal.download/cli.sh | sh \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the rocketship binary from builder
+COPY --from=builder /bin/rocketship /usr/local/bin/rocketship
+
+# Create a directory for test files
+RUN mkdir -p /tests
+
+# Environment variables that can be overridden
+ENV ENGINE_HOST=localhost:7700 \
+    TEST_DIR=/tests \
+    TEST_FILE=""
+
+# Copy entrypoint script
+COPY .docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/entrypoint.sh"] 

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -40,4 +40,4 @@ COPY .docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Set the entrypoint
-ENTRYPOINT ["/entrypoint.sh"] 
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -9,8 +9,10 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the rocketship CLI binary
-RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/rocketship ./cmd/rocketship
+# Build all binaries
+RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/rocketship ./cmd/rocketship \
+    && CGO_ENABLED=0 GOOS=linux go build -o /bin/worker ./cmd/worker \
+    && CGO_ENABLED=0 GOOS=linux go build -o /bin/engine ./cmd/engine
 
 # Create the final image
 FROM ubuntu:22.04
@@ -28,14 +30,19 @@ ENV PATH="/root/.temporalio/bin:${PATH}"
 
 WORKDIR /app
 
-# Copy the rocketship binary from builder
+# Copy all binaries from builder
 COPY --from=builder /bin/rocketship /usr/local/bin/rocketship
+COPY --from=builder /bin/worker /usr/local/bin/worker
+COPY --from=builder /bin/engine /usr/local/bin/engine
 
-# Create a directory for test files
-RUN mkdir -p /tests
+# Create directories for binaries and tests
+RUN mkdir -p /tests \
+    && mkdir -p /root/.cache/rocketship \
+    && ln -s /usr/local/bin/worker /root/.cache/rocketship/worker \
+    && ln -s /usr/local/bin/engine /root/.cache/rocketship/engine
 
 # Environment variables that can be overridden
-ENV ENGINE_HOST=localhost:7700 \
+ENV ENGINE_HOST=127.0.0.1:7700 \
     TEST_DIR=/tests \
     TEST_FILE=""
 

--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -19,8 +19,12 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
+    # we should pin a version
     && curl -sSf https://temporal.download/cli.sh | sh \
     && rm -rf /var/lib/apt/lists/*
+
+# Add Temporal CLI to PATH
+ENV PATH="/root/.temporalio/bin:${PATH}"
 
 WORKDIR /app
 

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,17 +1,24 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -eo pipefail
 
-# Start the rocketship server in background mode
+# 1. Start everything in the background
 rocketship start server --local --background
 
-# Run the tests based on environment variables
-if [ -n "$TEST_FILE" ]; then
-    echo "Running single test file: $TEST_FILE"
-    exec rocketship run --file "$TEST_FILE" --engine "$ENGINE_HOST"
-elif [ -n "$TEST_DIR" ]; then
-    echo "Running tests in directory: $TEST_DIR"
-    exec rocketship run --dir "$TEST_DIR" --engine "$ENGINE_HOST"
+# 2. Wait until the engine is actually accepting connections
+echo "🕐 waiting for Rocketship engine on :7700 ..."
+for i in {1..60}; do               # 60‑second timeout
+  (echo > /dev/tcp/127.0.0.1/7700) >/dev/null 2>&1 && break
+  sleep 1
+done || { echo "Timed out waiting for engine"; exit 1; }
+
+# 3. Run the tests
+if [[ -n "$TEST_FILE" ]]; then
+  echo "▶️  running single test file $TEST_FILE"
+  exec rocketship run --file "$TEST_FILE" --engine "${ENGINE_HOST:-127.0.0.1:7700}"
+elif [[ -n "$TEST_DIR" ]]; then
+  echo "▶️  running tests in dir $TEST_DIR"
+  exec rocketship run --dir  "$TEST_DIR" --engine "${ENGINE_HOST:-127.0.0.1:7700}"
 else
-    echo "Error: Neither TEST_FILE nor TEST_DIR is set"
-    exit 1
-fi 
+  echo "Error: neither TEST_FILE nor TEST_DIR is set"
+  exit 1
+fi

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -4,10 +4,6 @@ set -e
 # Start the rocketship server in background mode
 rocketship start server --local --background
 
-# Wait for the server to be ready (includes waiting for Temporal)
-echo "Waiting for rocketship server to be ready..."
-sleep 10
-
 # Run the tests based on environment variables
 if [ -n "$TEST_FILE" ]; then
     echo "Running single test file: $TEST_FILE"

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Start the rocketship server in background mode
+rocketship start server --local --background
+
+# Wait for the server to be ready (includes waiting for Temporal)
+echo "Waiting for rocketship server to be ready..."
+sleep 10
+
+# Run the tests based on environment variables
+if [ -n "$TEST_FILE" ]; then
+    echo "Running single test file: $TEST_FILE"
+    exec rocketship run --file "$TEST_FILE" --engine "$ENGINE_HOST"
+elif [ -n "$TEST_DIR" ]; then
+    echo "Running tests in directory: $TEST_DIR"
+    exec rocketship run --dir "$TEST_DIR" --engine "$ENGINE_HOST"
+else
+    echo "Error: Neither TEST_FILE nor TEST_DIR is set"
+    exit 1
+fi 

--- a/internal/cli/process_manager.go
+++ b/internal/cli/process_manager.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"sync"
@@ -38,18 +39,36 @@ func (pm *processManager) Cleanup() {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
+	// First pass: send SIGTERM to all processes
 	for _, proc := range pm.processes {
 		if proc != nil && proc.Process != nil {
-			// Send SIGTERM first for graceful shutdown
-			_ = proc.Process.Signal(syscall.SIGTERM)
-
-			// Give process time to shutdown gracefully
-			time.Sleep(2 * time.Second)
-
-			// Force kill if still running
-			_ = proc.Process.Kill()
+			log.Printf("Sending SIGTERM to process %d (%s)", proc.Process.Pid, proc.Path)
+			if err := proc.Process.Signal(syscall.SIGTERM); err != nil {
+				log.Printf("Failed to send SIGTERM to process %d: %v", proc.Process.Pid, err)
+			}
 		}
 	}
+
+	// Give processes time to shut down gracefully
+	time.Sleep(2 * time.Second)
+
+	// Second pass: check if processes are still running and force kill if necessary
+	for _, proc := range pm.processes {
+		if proc != nil && proc.Process != nil {
+			// Check if process is still running
+			if err := proc.Process.Signal(syscall.Signal(0)); err == nil {
+				log.Printf("Process %d still running, sending SIGKILL", proc.Process.Pid)
+				if err := proc.Process.Kill(); err != nil {
+					log.Printf("Failed to kill process %d: %v", proc.Process.Pid, err)
+				}
+			} else {
+				log.Printf("Process %d has exited", proc.Process.Pid)
+			}
+		}
+	}
+
+	// Clear the processes list
+	pm.processes = make([]*exec.Cmd, 0)
 }
 
 // SaveToFile saves the process manager state to a file
@@ -93,12 +112,23 @@ func LoadFromFile(path string) (*processManager, error) {
 
 	pm := newProcessManager()
 	for _, ps := range state {
+		log.Printf("Looking for process %d (%s)", ps.PID, ps.Path)
 		proc, err := os.FindProcess(ps.PID)
-		if err == nil {
-			cmd := exec.Command(ps.Path)
-			cmd.Process = proc
-			pm.Add(cmd)
+		if err != nil {
+			log.Printf("Failed to find process %d: %v", ps.PID, err)
+			continue
 		}
+
+		// Check if process is actually running
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			log.Printf("Process %d is not running: %v", ps.PID, err)
+			continue
+		}
+
+		cmd := exec.Command(ps.Path)
+		cmd.Process = proc
+		pm.Add(cmd)
+		log.Printf("Found running process %d", ps.PID)
 	}
 
 	return pm, nil

--- a/internal/cli/process_manager.go
+++ b/internal/cli/process_manager.go
@@ -1,11 +1,20 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
 )
+
+// processState represents the serializable state of a process
+type processState struct {
+	PID  int    `json:"pid"`
+	Path string `json:"path"`
+}
 
 // processManager handles the lifecycle of child processes
 type processManager struct {
@@ -41,4 +50,56 @@ func (pm *processManager) Cleanup() {
 			_ = proc.Process.Kill()
 		}
 	}
+}
+
+// SaveToFile saves the process manager state to a file
+func (pm *processManager) SaveToFile(path string) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	var state []processState
+	for _, proc := range pm.processes {
+		if proc != nil && proc.Process != nil {
+			state = append(state, processState{
+				PID:  proc.Process.Pid,
+				Path: proc.Path,
+			})
+		}
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal process state: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write process state: %w", err)
+	}
+
+	return nil
+}
+
+// LoadFromFile loads process manager state from a file
+func LoadFromFile(path string) (*processManager, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read process state: %w", err)
+	}
+
+	var state []processState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal process state: %w", err)
+	}
+
+	pm := newProcessManager()
+	for _, ps := range state {
+		proc, err := os.FindProcess(ps.PID)
+		if err == nil {
+			cmd := exec.Command(ps.Path)
+			cmd.Process = proc
+			pm.Add(cmd)
+		}
+	}
+
+	return pm, nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(
 		NewStartCmd(),
 		NewRunCmd(),
+		NewStopCmd(),
 	)
 
 	return cmd

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -40,7 +41,16 @@ func newStartServerCmd() *cobra.Command {
 				return err
 			}
 
+			isBackground, err := cmd.Flags().GetBool("background")
+			if err != nil {
+				return err
+			}
+
 			if isLocal {
+				if isBackground {
+					// Start processes and return immediately
+					return setupLocalEnvironmentBackground()
+				}
 				return setupLocalEnvironment()
 			}
 
@@ -49,6 +59,7 @@ func newStartServerCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("local", false, "Start local development environment")
+	cmd.Flags().Bool("background", false, "Start server in background mode")
 	return cmd
 }
 
@@ -151,4 +162,63 @@ func setupLocalEnvironment() error {
 	// Keep the parent process running until context is cancelled
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+// setupLocalEnvironmentBackground starts all processes but doesn't wait for context cancellation
+func setupLocalEnvironmentBackground() error {
+	// Create a context that we can cancel
+	ctx := context.Background()
+
+	// Set up process manager
+	pm := newProcessManager()
+
+	// Start Temporal server
+	log.Println("Starting Temporal server...")
+	temporalCmd := exec.CommandContext(ctx, "temporal", "server", "start-dev")
+	temporalCmd.Stderr = os.Stderr
+	temporalCmd.Stdout = os.Stdout
+	if err := temporalCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start temporal server: %w", err)
+	}
+	pm.Add(temporalCmd)
+
+	// Give Temporal a moment to start
+	time.Sleep(5 * time.Second)
+
+	// Set environment variables for worker and engine
+	if err := os.Setenv("TEMPORAL_HOST", "localhost:7233"); err != nil {
+		return fmt.Errorf("failed to set TEMPORAL_HOST environment variable: %w", err)
+	}
+
+	// Start the worker from embedded binary
+	log.Println("Starting Rocketship worker...")
+	workerCmd, err := embedded.ExtractAndRun("worker", nil, []string{"TEMPORAL_HOST=localhost:7233"})
+	if err != nil {
+		return fmt.Errorf("failed to start worker: %w", err)
+	}
+	if err := workerCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start worker: %w", err)
+	}
+	pm.Add(workerCmd)
+
+	// Start the engine from embedded binary
+	log.Println("Starting Rocketship engine...")
+	engineCmd, err := embedded.ExtractAndRun("engine", nil, []string{"TEMPORAL_HOST=localhost:7233"})
+	if err != nil {
+		return fmt.Errorf("failed to start engine: %w", err)
+	}
+	if err := engineCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start engine: %w", err)
+	}
+	pm.Add(engineCmd)
+
+	log.Println("Local development environment is ready! 🚀")
+
+	// Write the process manager to a file so we can clean up later if needed
+	pidFile := filepath.Join(os.TempDir(), "rocketship-server.pid")
+	if err := pm.SaveToFile(pidFile); err != nil {
+		log.Printf("Warning: Failed to save process manager state: %v", err)
+	}
+
+	return nil
 }

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// NewStopCmd creates a new stop command
+func NewStopCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop rocketship components",
+		Long:  `Stop rocketship components like the server.`,
+	}
+
+	cmd.AddCommand(newStopServerCmd())
+
+	return cmd
+}
+
+func newStopServerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Stop the rocketship server",
+		Long:  `Stop the rocketship server and all its components.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pidFile := filepath.Join(os.TempDir(), "rocketship-server.pid")
+
+			// Load process manager state
+			pm, err := LoadFromFile(pidFile)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("no running server found")
+				}
+				return fmt.Errorf("failed to load process state: %w", err)
+			}
+
+			// Clean up processes
+			pm.Cleanup()
+
+			// Remove PID file
+			if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("failed to remove PID file: %w", err)
+			}
+
+			fmt.Println("Server components stopped successfully! 🛑")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -49,6 +49,12 @@ func newStopServerCmd() *cobra.Command {
 				log.Printf("Warning: Failed to remove PID file: %v", err)
 			}
 
+			// Clean up log files
+			logsDir := filepath.Join(os.TempDir(), "rocketship-logs")
+			if err := os.RemoveAll(logsDir); err != nil {
+				log.Printf("Warning: Failed to remove logs directory: %v", err)
+			}
+
 			fmt.Println("Server components stopped successfully! 🛑")
 			return nil
 		},

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	defaultVersion   = "v0.2.0" // This should be updated with each release
+	defaultVersion   = "v0.3.0" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request introduces a variety of changes to enhance the Rocketship CLI, including a new Docker-based development environment, improved process management, and new CLI commands for starting and stopping the server. The primary focus is on improving usability, automation, and maintainability for local development workflows.

### Docker Environment Setup:
* Added a new multi-stage Dockerfile (`.docker/Dockerfile.cli`) to build the Rocketship CLI and set up a runtime environment with dependencies like Temporal CLI. This includes environment variables for test configurations and an entrypoint script.
* Created an entrypoint script (`.docker/entrypoint.sh`) to start the server in the background, wait for readiness, and run tests based on environment variables.

### Process Management Enhancements:
* Introduced `processState` and methods to serialize/deserialize process state in `internal/cli/process_manager.go`. This allows saving and restoring process states for better lifecycle management. [[1]](diffhunk://#diff-72ccfe6212e322c2d8545e35059a99a2d711ebde118e2eb0270d1c83b7e17aadR4-R19) [[2]](diffhunk://#diff-72ccfe6212e322c2d8545e35059a99a2d711ebde118e2eb0270d1c83b7e17aadR42-R134)
* Enhanced the `Cleanup` method to log process termination attempts and added a second pass to force-kill lingering processes.

### CLI Improvements:
* Added a `stop` command (`internal/cli/stop.go`) to terminate server components and clean up resources like log files and PID files.
* Updated the `start` command (`internal/cli/start.go`) with a `--background` flag to allow starting the server in the background. This includes a new `setupLocalEnvironmentBackground` function for managing background processes and logs. [[1]](diffhunk://#diff-7a6c7b69235cfd1928f72edb7f262f46a0bec09b7308635f82ffe3b0723feb08R44-R53) [[2]](diffhunk://#diff-7a6c7b69235cfd1928f72edb7f262f46a0bec09b7308635f82ffe3b0723feb08R166-R257)

### Version Updates:
* Updated the default version of embedded binaries to `v0.3.0` in `internal/embedded/binaries.go`.