### PR TITLE
Add multi arc publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
           prerelease: false
           generate_release_notes: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -89,6 +92,7 @@ jobs:
         with:
           context: .
           file: .docker/Dockerfile.cli
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             rocketshipai/rocketship:${{ steps.get_version.outputs.VERSION }}

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	defaultVersion   = "v0.3.1" // This should be updated with each release
+	defaultVersion   = "v0.3.2" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request introduces updates to the release workflow and embedded binaries to enhance multi-platform support and prepare for the next release version. The most significant changes include adding QEMU setup for cross-platform builds, updating Docker build settings to support multiple architectures, and incrementing the default version of the embedded binaries.

### Workflow improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R74-R76): Added a step to set up QEMU using `docker/setup-qemu-action@v3` to enable cross-platform builds.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R95): Updated Docker build settings to specify `linux/amd64` and `linux/arm64` as target platforms for multi-architecture image builds.

### Embedded binaries:
* [`internal/embedded/binaries.go`](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L16-R16): Updated the `defaultVersion` constant from `v0.3.1` to `v0.3.2` to align with the upcoming release.