### PR TITLE
bump to v0.4.0

### DIFF
--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	defaultVersion   = "v0.3.2" // This should be updated with each release
+	defaultVersion   = "v0.4.0" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request updates the default version of the Rocketship binary in the `internal/embedded/binaries.go` file to reflect the latest release.

* [`internal/embedded/binaries.go`](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L16-R16): Updated `defaultVersion` from `"v0.3.2"` to `"v0.4.0"` to align with the new release version.