### PR TITLE
Fix Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: .docker/Dockerfile.cli
+          file: .docker/ci-testing/Dockerfile.cli
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v1.0.0" // This should be updated with each release
+	DefaultVersion   = "v1.0.1" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request includes updates to the Dockerfile path in the release workflow and a version bump for the default binary version in the codebase.

### Workflow updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L94-R94): Updated the Dockerfile path in the release workflow from `.docker/Dockerfile.cli` to `.docker/ci-testing/Dockerfile.cli` to reflect the new location for CI testing.

### Version updates:
* [`internal/embedded/binaries.go`](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L16-R16): Incremented the `DefaultVersion` constant from `v1.0.0` to `v1.0.1` to align with the latest release.