### PR TITLE
Fix the non-deterministic behavior of TestWorkflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto lint test build compose-up install clean prepare-embed dev-setup docs docs-serve docs-deps docs-clean
+.PHONY: proto lint test build compose-up install clean prepare-embed dev-setup docs docs-serve docs-deps docs-clean install-workflowcheck
 
 prepare-embed:
 	@mkdir -p internal/embedded/bin
@@ -17,10 +17,17 @@ build: build-binaries
 	go test ./...
 	go build -o bin/rocketship cmd/rocketship/main.go
 
+install-workflowcheck:
+	@if ! command -v workflowcheck &> /dev/null; then \
+		go install go.temporal.io/sdk/contrib/tools/workflowcheck@latest; \
+	fi
+
 # Run linting
-lint: build-binaries
+lint: build-binaries install-workflowcheck
 	@echo "Running linter..."
 	golangci-lint run
+	@echo "Checking workflows..."
+	workflowcheck ./...
 
 # Run tests
 test: build-binaries
@@ -46,7 +53,7 @@ install: build
 dev-setup: prepare-embed
 	@echo "Setting up development environment..."
 	@if [ ! -f .git/hooks/pre-commit ]; then \
-		./for-maintainers/setup-hooks.sh; \
+		./for-contributors/setup-hooks.sh; \
 	fi
 	@echo "Building initial binaries..."
 	@$(MAKE) build-binaries

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -51,7 +51,7 @@ rocketship run --file <path/to/rocketship.yaml> --engine localhost:7700
    Inside [for-contributors/](https://github.com/rocketship-ai/rocketship/blob/main/for-contributors), you'll find a test server that you can run with:
 
 ```bash
-go run for-contributors/test-server/main.go
+cd ./for-contributors/test-server && go run .
 ```
 
 This will help you test your changes with an in-memory store that can preserve resources.

--- a/internal/interpreter/workflow.go
+++ b/internal/interpreter/workflow.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	// plugins
+
 	"github.com/rocketship-ai/rocketship/internal/plugins/delay"
 	"github.com/rocketship-ai/rocketship/internal/plugins/http"
 )
@@ -56,6 +57,7 @@ func TestWorkflow(ctx workflow.Context, test dsl.Test) error {
 }
 
 func handleDelayStep(ctx workflow.Context, step dsl.Step) error {
+	//workflowcheck:ignore
 	dp, err := delay.ParseYAML(step)
 	if err != nil {
 		return fmt.Errorf("step %q: %w", step.Name, err)
@@ -74,6 +76,7 @@ func handleHTTPStep(ctx workflow.Context, step dsl.Step, state map[string]string
 	logger.Info(fmt.Sprintf("Executing HTTP step: %s", step.Name))
 	logger.Info(fmt.Sprintf("Current state: %v", state))
 
+	//workflowcheck:ignore
 	hp, err := http.ParseYAML(step)
 	if err != nil {
 		return fmt.Errorf("failed to parse HTTP step: %w", err)
@@ -98,9 +101,10 @@ func handleHTTPStep(ctx workflow.Context, step dsl.Step, state map[string]string
 
 	// Update workflow state with saved values
 	logger.Info(fmt.Sprintf("Saved values from step: %v", activityResp.Saved))
-	for key, value := range activityResp.Saved {
-		state[key] = value
-		logger.Info(fmt.Sprintf("Updated state[%s] = %s", key, value))
+	keys := workflow.DeterministicKeys(activityResp.Saved)
+	for _, key := range keys {
+		state[key] = activityResp.Saved[key]
+		logger.Info(fmt.Sprintf("Updated state[%s] = %s", key, state[key]))
 	}
 	logger.Info(fmt.Sprintf("Updated state: %v", state))
 

--- a/internal/interpreter/workflow.go
+++ b/internal/interpreter/workflow.go
@@ -9,7 +9,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	// plugins
-
 	"github.com/rocketship-ai/rocketship/internal/plugins/delay"
 	"github.com/rocketship-ai/rocketship/internal/plugins/http"
 )


### PR DESCRIPTION
This PR fixes the non deterministic behavior of TestWorkflow caused by directly calling `[PLUGIN].ParseYAML()`.

Another approach could be to delegating each raw Step directly to the desigred plugin, this means changing the plugins activity signature to something like:

```go
type PluginParam struct {
    Step dsl.Step
    State map[string]string
}

// Having a structured result type would also help to notify developers
// what are some general fields that are expected and/or common
type PluginResult {
    Response any     `json:"response"`
    Saved    map[string]string `json:"saved"`
}

Activity(ctx context.Context, p PluginParam) (PluginResult, error) {}
```
