### PR TITLE
add claude code md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Architecture Overview
+
+Rocketship is an open-source testing engine for E2E API testing that uses Temporal for durable execution. The system is built with Go and follows a plugin-based architecture.
+
+**Key Components:**
+
+- **CLI (`cmd/rocketship/`)**: Main entry point that wraps the engine and worker binaries
+- **Engine (`cmd/engine/`)**: gRPC server that orchestrates test execution via Temporal workflows
+- **Worker (`cmd/worker/`)**: Temporal worker that executes test workflows using plugins
+- **Plugins (`internal/plugins/`)**: Extensible system for different protocols (HTTP, delay, AWS services)
+- **DSL Parser (`internal/dsl/`)**: Parses YAML test specifications into executable workflows
+- **Orchestrator (`internal/orchestrator/`)**: Engine implementation that manages test runs and streaming logs
+
+**Test Flow:**
+
+1. YAML spec is parsed by DSL parser
+2. Engine creates Temporal workflows for each test
+3. Worker executes test steps using appropriate plugins
+4. Results are streamed back via gRPC to CLI
+
+## Development Commands
+
+### Build and Install
+
+```bash
+make build          # Build CLI with embedded binaries
+make install        # Install CLI to $GOPATH/bin
+make dev-setup      # Set up development environment with git hooks
+```
+
+### Testing and Quality
+
+```bash
+make test           # Run all tests
+make lint           # Run golangci-lint and workflowcheck
+go test ./...       # Run tests for specific packages
+```
+
+### Embedded Binaries
+
+The CLI embeds engine and worker binaries. Always run `make build-binaries` after modifying engine/worker code.
+
+### Protocol Buffers
+
+```bash
+make proto          # Regenerate protobuf code from proto/engine.proto
+```
+
+### Documentation
+
+```bash
+make docs-serve     # Start local documentation server
+make docs           # Build documentation
+```
+
+## Test Specifications
+
+Tests are defined in YAML files with this structure:
+
+- `name`: Test suite name
+- `tests[]`: Array of test cases
+- `tests[].steps[]`: Sequential steps within a test
+- `steps[].plugin`: Plugin to use (http, delay, aws/\*)
+- `steps[].assertions[]`: Validation rules
+- `steps[].save[]`: Variable extraction for step chaining
+
+## Plugin System
+
+Plugins implement the `Plugin` interface in `internal/plugins/plugin.go`. Each plugin has:
+
+- `Execute()`: Main execution logic
+- `Parse()`: Configuration parsing
+- Plugin-specific types in separate files
+
+Current plugins: HTTP, delay, AWS (S3, SQS, DynamoDB)
+
+## Running Tests
+
+```bash
+rocketship run -af test.yaml    # Auto-start local engine, run tests, auto-stop engine
+rocketship start server -lb     # Start engine in locally, in the background
+rocketship run test.yaml        # Run against existing engine
+rocketship stop server          # Stop local background engine
+```


### PR DESCRIPTION
This pull request adds a new `CLAUDE.md` file to provide guidance for working with the Rocketship repository. The document includes an architecture overview, development commands, test specifications, plugin system details, and instructions for running tests.

### Documentation Additions:

* **Architecture Overview**: Describes Rocketship's key components, including the CLI, engine, worker, plugins, DSL parser, and orchestrator, along with the test flow from YAML parsing to result streaming. (`[CLAUDE.mdR1-R88](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R88)`)
* **Development Commands**: Lists commands for building, testing, linting, generating protobufs, and managing documentation. (`[CLAUDE.mdR1-R88](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R88)`)
* **Test Specifications**: Explains the YAML structure for defining test cases, including steps, plugins, assertions, and variable extraction. (`[CLAUDE.mdR1-R88](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R88)`)
* **Plugin System**: Details the `Plugin` interface and current plugin implementations (HTTP, delay, AWS). (`[CLAUDE.mdR1-R88](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R88)`)
* **Running Tests**: Provides CLI commands for running tests and managing the engine lifecycle. (`[CLAUDE.mdR1-R88](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R88)`)