### PR TITLE
fix: CLI version upgrading patch

### DIFF
--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v1.5.1" // This should be updated with each release
+	DefaultVersion   = "v1.5.2" // This should be updated with each release
 )
 
 type binaryMetadata struct {

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -61,9 +61,9 @@ func ExtractAndRun(name string, args []string, env []string) (*exec.Cmd, error) 
 				targetVersion = envVersion
 				needsExtract = metadata.Version != envVersion
 			} else {
-				// Otherwise use the version that was originally installed
-				targetVersion = metadata.Version
-				needsExtract = false
+				// Otherwise use the current CLI's version and re-extract if cached version differs
+				targetVersion = DefaultVersion
+				needsExtract = metadata.Version != DefaultVersion
 			}
 		}
 	}


### PR DESCRIPTION
This pull request addresses a bug in version handling for embedded binaries and improves test coverage to ensure correctness. The changes primarily focus on ensuring that the correct version of binaries is used and re-extracted when necessary, along with adding a new test to validate the logic.

### Bug Fixes for Version Handling:
* [`internal/embedded/binaries.go`](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L64-R66): Updated the logic in `ExtractAndRun` to use the current CLI version (`DefaultVersion`) for determining whether binaries need to be re-extracted, instead of relying on the cached version. This ensures consistency when the CLI is upgraded.

### Version Update:
* [`internal/embedded/binaries.go`](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L16-R16): Updated `DefaultVersion` from `v1.5.1` to `v1.5.2`, reflecting the latest release.

### Test Coverage Improvements:
* [`internal/embedded/binaries_test.go`](diffhunk://#diff-4789568ba3f2220bbc057ef0f10d2bbf2f03037b7a2128bed0fa305f3a0fea39R379-R470): Added a new test function `TestVersionUpgradeBugFix` to verify the behavior of version handling logic, including scenarios with CLI upgrades, cached binaries, and environment variable overrides.