### PR TITLE
Fix Release Workflow by adding provenance: false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
           file: .docker/ci-testing/Dockerfile.cli
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             rocketshipai/rocketship:${{ steps.get_version.outputs.VERSION }}
             rocketshipai/rocketship:latest
@@ -105,6 +106,7 @@ jobs:
           file: .docker/Dockerfile.engine
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             rocketshipai/rocketship-engine:${{ steps.get_version.outputs.VERSION }}
             rocketshipai/rocketship-engine:latest
@@ -116,6 +118,7 @@ jobs:
           file: .docker/Dockerfile.worker
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: |
             rocketshipai/rocketship-worker:${{ steps.get_version.outputs.VERSION }}
             rocketshipai/rocketship-worker:latest

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v1.7.0" // This should be updated with each release
+	DefaultVersion   = "v1.7.1" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to disable provenance generation for Docker images during the release workflow. The changes ensure that the `provenance` field is explicitly set to `false` for all specified Dockerfiles.

### Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R97): Added `provenance: false` to the job building the CLI Docker image (`.docker/ci-testing/Dockerfile.cli`).
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R109): Added `provenance: false` to the job building the engine Docker image (`.docker/Dockerfile.engine`).
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R121): Added `provenance: false` to the job building the worker Docker image (`.docker/Dockerfile.worker`).