### PR TITLE
Fix browser plugin: embed browser_automation.py in binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,11 @@ Plugins implement the `Plugin` interface in `internal/plugins/plugin.go`. Each p
 - `Parse()`: Configuration parsing
 - Plugin-specific types in separate files
 
-Current plugins: HTTP, delay, AWS (S3, SQS, DynamoDB)
+Current plugins: HTTP, delay, AWS (S3, SQS, DynamoDB), SQL, log, script, agent, browser, supabase
+
+### Browser Plugin Notes
+
+The browser plugin uses AI-driven web automation via the `browser-use` Python library. The Python script (`browser_automation.py`) is embedded into the binary using `go:embed` to ensure it's available at runtime.
 
 ## Running Tests
 
@@ -146,4 +150,19 @@ Spin down the containers when you're done
 
 ```bash
 docker-compose -f .docker/docker-compose.yaml down
+```
+
+## Running Tests with Browser Plugin
+
+The browser plugin requires Python 3.11+ and browser-use installed:
+
+```bash
+# Install browser-use and its dependencies
+pip install browser-use playwright langchain-openai langchain-anthropic
+
+# Install Playwright browsers
+playwright install chromium
+
+# Run browser tests
+rocketship run -af examples/browser-automation/rocketship.yaml
 ```

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.1" // This should be updated with each release
+	DefaultVersion   = "v0.5.2" // This should be updated with each release
 )
 
 type binaryMetadata struct {

--- a/internal/plugins/browser/python_executor.go
+++ b/internal/plugins/browser/python_executor.go
@@ -3,17 +3,20 @@ package browser
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 )
+
+//go:embed browser_automation.py
+var embeddedPythonScript []byte
 
 // PythonExecutor implements browser automation using Python and browser-use
 type PythonExecutor struct{}
@@ -166,23 +169,8 @@ func (pe *PythonExecutor) Execute(ctx context.Context, config *Config) (*Browser
 
 // copyPythonScript copies the Python automation script to the work directory
 func (pe *PythonExecutor) copyPythonScript(scriptPath string) error {
-	// Get the directory of the current Go file
-	_, currentFile, _, ok := runtime.Caller(0)
-	if !ok {
-		return fmt.Errorf("failed to get current file path")
-	}
-	
-	// Path to the Python script relative to this Go file
-	sourceScript := filepath.Join(filepath.Dir(currentFile), "browser_automation.py")
-	
-	// Read the source script
-	scriptContent, err := os.ReadFile(sourceScript)
-	if err != nil {
-		return fmt.Errorf("failed to read Python script from %s: %w", sourceScript, err)
-	}
-	
-	// Write to destination
-	return os.WriteFile(scriptPath, scriptContent, 0755)
+	// Write the embedded Python script to destination
+	return os.WriteFile(scriptPath, embeddedPythonScript, 0755)
 }
 
 // buildEnvironment builds the environment variables for the Python process

--- a/internal/plugins/browser/python_executor_test.go
+++ b/internal/plugins/browser/python_executor_test.go
@@ -1,0 +1,44 @@
+package browser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEmbeddedPythonScript(t *testing.T) {
+	// Test that the embedded Python script is not empty
+	if len(embeddedPythonScript) == 0 {
+		t.Fatal("embedded Python script is empty")
+	}
+
+	// Test that we can write the embedded script to a file
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "test_browser_automation.py")
+	
+	pe := &PythonExecutor{}
+	err := pe.copyPythonScript(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to copy Python script: %v", err)
+	}
+
+	// Verify the file was created and has content
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to stat copied script: %v", err)
+	}
+
+	if info.Size() == 0 {
+		t.Fatal("copied script is empty")
+	}
+
+	// Verify the content matches
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read copied script: %v", err)
+	}
+
+	if len(content) != len(embeddedPythonScript) {
+		t.Fatalf("copied script size mismatch: got %d, want %d", len(content), len(embeddedPythonScript))
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes the `browser_automation.py: no such file or directory` error when using the browser plugin with compiled binaries
- The Python script is now embedded at compile time using `go:embed` directive
- Added test coverage to verify embedded script functionality

## Problem
The browser plugin was using `runtime.Caller(0)` to locate the Python script relative to the Go source file. This works during development but fails in compiled binaries because the source files don't exist at runtime. The error path showed it was looking for files in the GitHub Actions build environment path.

## Solution
- Added `//go:embed browser_automation.py` directive to embed the Python script into the binary
- Removed the runtime file path resolution logic
- The embedded script is now written directly to the temporary work directory

## Test Plan
- [x] Added unit test to verify embedded script is not empty and can be written to disk
- [x] Test passes: `go test -v ./internal/plugins/browser -run TestEmbeddedPythonScript`
- [ ] CI tests should pass
- [ ] Browser plugin should work with compiled binaries

🤖 Generated with [Claude Code](https://claude.ai/code)