### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Build release artifacts
         run: |
@@ -98,14 +98,14 @@ jobs:
         run: |
           # Install dependencies
           npm ci
-          
+
           # Build with embedded knowledge
           npm run build
-          
+
           # Set version to match release tag (remove 'v' prefix)
           VERSION_NUMBER=${GITHUB_REF#refs/tags/v}
           npm version $VERSION_NUMBER --no-git-tag-version
-          
+
           # Publish to npm
           npm publish --access public
         env:
@@ -115,7 +115,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: .docker/ci-testing/Dockerfile.cli
+          file: .docker/Dockerfile.cli
           platforms: linux/amd64,linux/arm64
           push: true
           provenance: false

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.8" // This should be updated with each release
+	DefaultVersion   = "v0.5.9" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request includes updates to the release workflow and a version bump for the default binary version. The changes ensure compatibility with the latest release and streamline the Dockerfile configuration.

### Workflow updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L118-R118): Updated the Dockerfile path in the `docker/build-push-action` step to use `.docker/Dockerfile.cli` instead of `.docker/ci-testing/Dockerfile.cli`. This reflects a reorganization of Dockerfile locations.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L27-R28): Standardized the use of double quotes for `node-version` and `registry-url` in the `setup-node` step for consistency.

### Version update:
* [`internal/embedded/binaries.go`](diffhunk://#diff-fc06b72377ce959db40e16d25dc0c048f0c03e48daff3703c9e109414463f388L16-R16): Updated the `DefaultVersion` constant from `v0.5.8` to `v0.5.9` to align with the latest release.