### PR TITLE
Add --debug flag and enhanced browser plugin logging

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,19 +1,32 @@
 package cli
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
 // NewRootCmd creates a new root command
 func NewRootCmd() *cobra.Command {
-	// Initialize logging at the root level
-	InitLogging()
-
 	cmd := &cobra.Command{
 		Use:   "rocketship",
 		Short: "Rocketship CLI",
 		Long:  `Rocketship is a CLI tool for running automated tests.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Check if debug flag is set
+			debug, _ := cmd.Flags().GetBool("debug")
+			if debug {
+				// Set the environment variable for debug logging
+				_ = os.Setenv("ROCKETSHIP_LOG", "DEBUG")
+			}
+			
+			// Initialize logging after potentially setting the debug env var
+			InitLogging()
+		},
 	}
+
+	// Add persistent flags
+	cmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 
 	// Add subcommands
 	cmd.AddCommand(

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.10" // This should be updated with each release
+	DefaultVersion   = "v0.5.11" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
## Summary
- Add global `--debug` flag to CLI as a convenient alternative to `ROCKETSHIP_LOG=DEBUG`
- Enhanced browser plugin logging that shows browser-use library output in real-time when debug mode is enabled
- Maintains backward compatibility with existing `ROCKETSHIP_LOG` environment variable

## Features

### Global --debug Flag
- Works with **all subcommands** (run, start, stop, validate, etc.)
- Replaces the need for `ROCKETSHIP_LOG=DEBUG` environment variable
- Follows standard CLI conventions
- Auto-generates in documentation via Cobra

### Enhanced Browser Plugin Logging
- **Debug mode**: Streams Python stdout/stderr in real-time with clear `[BROWSER-USE]` prefixes
- **Non-debug mode**: Works exactly as before (no changes)
- Shows browser-use library logs, LLM initialization, browser profile creation, etc.
- Improves debugging experience for browser automation issues

## Usage Examples

```bash
# Instead of:
ROCKETSHIP_LOG=DEBUG rocketship run -af test.yaml

# Users can now use:
rocketship --debug run -af test.yaml
rocketship --debug validate test.yaml
rocketship --debug start server
```

## Debug Output Sample
```
[BROWSER-USE] Successfully imported browser_use
[BROWSER-USE] OpenAI LLM initialized with model: gpt-4o
[BROWSER-USE] Creating browser agent...
[BROWSER-USE] Browser profile created: headless=true, type=chromium
```

## Test plan
- [x] Added global `--debug` flag appears in help output
- [x] Debug flag works with all subcommands  
- [x] Browser plugin streams logs in real-time when debug enabled
- [x] Non-debug mode works unchanged
- [x] All existing tests pass
- [x] Documentation auto-generates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)