### PR TITLE
Pr 2/engine http health endpoint

### DIFF
--- a/cmd/engine/health_test.go
+++ b/cmd/engine/health_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+	server := httptest.NewServer(newHealthMux())
+	defer server.Close()
+
+	paths := []string{"/", "/healthz"}
+
+	for _, path := range paths {
+		resp, err := http.Get(server.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s failed: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200 for %s, got %d", path, resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("expected content-type application/json for %s, got %s", path, ct)
+		}
+
+		var payload healthPayload
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode response for %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+
+		if payload.Status != "ok" {
+			t.Fatalf("expected status ok for %s, got %s", path, payload.Status)
+		}
+	}
+}

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.14" // This should be updated with each release
+	DefaultVersion   = "v0.5.15" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request introduces a new HTTP health check server to the engine, providing a simple JSON endpoint for service health monitoring. It also bumps the default embedded binary version. The main changes are grouped below:

**Health Check Server Addition:**

* Added a lightweight HTTP health server that listens on port `7701` and responds with a JSON payload indicating service health at both `/` and `/healthz` endpoints (`cmd/engine/main.go`). [[1]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R40-R60) [[2]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R80-R95)
* Introduced the `healthPayload` struct and the `newHealthMux` function to standardize health check responses (`cmd/engine/main.go`).

**Testing:**

* Implemented a unit test in `cmd/engine/health_test.go` to verify the health endpoints return the correct status code, content type, and payload.

**Version Update:**

* Updated the `DefaultVersion` constant in `internal/embedded/binaries.go` from `"v0.5.14"` to `"v0.5.15"`.