### PR TITLE
Acknowledge current openAPI spec validator issues

### DIFF
--- a/docs/src/examples/http/openapi-validation.md
+++ b/docs/src/examples/http/openapi-validation.md
@@ -13,7 +13,7 @@ openapi:
 ```
 
 - `spec` accepts relative or absolute filesystem paths **and** HTTP(S) URLs.
-- YAML and JSON OpenAPI documents are both supported; kin-openapi auto-detects the format.
+- YAML and JSON OpenAPI documents are both supported; `github.com/pb33f/libopenapi-validator` auto-detects the format.
 - `cache_ttl` controls how long a contract stays cached (default 30 minutes). Raise or lower it depending on how often specs change.
 - Bump the optional `version` string (`version: "2024-03-15"`) whenever you publish a new contract to force an immediate refresh.
 - Form-encoded payloads (`application/x-www-form-urlencoded`) and other common content types are validated automatically—just use the HTTP plugin’s `form` config block.
@@ -58,13 +58,20 @@ Every HTTP step inherits that contract. One step turns off `validate_request` to
       validate_request: false
 ```
 
-With the contract in place, Rocketship fails the run if the server returns extra fields, the wrong status code, or a payload that violates the schema. All failures include the underlying kin-openapi error details.
+With the contract in place, Rocketship fails the run if the server returns extra fields, the wrong status code, or a payload that violates the schema. All failures include the underlying `libopenapi-validator` error details.
 
 ## Cache Behaviour
 
 - Entries expire automatically after the configured `cache_ttl`.
 - Local specs refresh as soon as their modification time changes.
 - Remote specs refresh when the TTL expires or when you bump the `version` field.
+
+## Known Issues
+
+- Literal paths can still lose precedence to templated paths in `libopenapi-validator` (see `/Messages/Operations` vs `/Messages/{message_id}`) until the upstream matcher is fixed.
+- The validator currently skips `multipart/form-data` and other complex encodings because the upstream library lacks decoders for those media types.
+- Server `host`/`scheme` variables, callbacks, webhooks, and links defined in the OpenAPI document are not yet validated.
+- Validation errors come directly from `github.com/pb33f/libopenapi-validator`; behaviour may change as the library evolves.
 
 ## Next Steps
 

--- a/internal/plugins/http/http_test.go
+++ b/internal/plugins/http/http_test.go
@@ -1093,6 +1093,36 @@ paths:
 		t.Fatalf("failed to write base path spec: %v", err)
 	}
 
+	pathPrecedenceSpec := `openapi: 3.1.0
+info:
+  title: Path Precedence Bug
+  version: 1.0.0
+paths:
+  /Messages/{message_id}:
+    parameters:
+      - name: message_id
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: '^comms_message_[0-7][a-hjkmnpqrstv-z0-9]{25,34}'
+    get:
+      responses:
+        '200':
+          description: OK
+  /Messages/Operations:
+    get:
+      summary: List Operations
+      responses:
+        '200':
+          description: OK
+`
+
+	pathPrecedenceSpecPath := filepath.Join(tempDir, "path-precedence-openapi.yaml")
+	if err := os.WriteFile(pathPrecedenceSpecPath, []byte(pathPrecedenceSpec), 0o600); err != nil {
+		t.Fatalf("failed to write path precedence spec: %v", err)
+	}
+
 	t.Run("server base path matches request", func(t *testing.T) {
 		t.Parallel()
 
@@ -1112,6 +1142,49 @@ paths:
 		}
 		if err := validator.validateRequest(ctx); err != nil {
 			t.Fatalf("expected request validation to pass with server base path, got %v", err)
+		}
+	})
+
+	t.Run("literal path takes precedence over parameterized path", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		suite := map[string]interface{}{"spec": pathPrecedenceSpecPath}
+
+		validator, err := newOpenAPIValidator(ctx, map[string]interface{}{}, suite, nil)
+		if err != nil {
+			t.Fatalf("unexpected error creating validator: %v", err)
+		}
+
+		var (
+			paramOp   *operationMatcher
+			literalOp *operationMatcher
+		)
+		for _, op := range validator.entry.operations {
+			switch op.template {
+			case "/Messages/{message_id}":
+				paramOp = op
+			case "/Messages/Operations":
+				literalOp = op
+			}
+		}
+		if paramOp == nil || literalOp == nil {
+			t.Fatalf("expected both literal and parameterized operations to be present")
+		}
+
+		// Force the parameterized operation to be evaluated before the literal one to simulate the reported bug.
+		validator.entry.operations = []*operationMatcher{paramOp, literalOp}
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/Messages/Operations?start_date=2020-01-01T00:00:00Z&end_date=2025-12-31T23:59:59Z&page_size=10", nil)
+		setRequestBody(req, nil)
+
+		if err := validator.prepareRequestValidation(ctx, req, nil); err != nil {
+			t.Fatalf("unexpected error preparing validation: %v", err)
+		}
+		if err := validator.validateRequest(ctx); err == nil {
+			t.Fatalf("expected request validation to fail when literal path loses precedence")
+		} else if !strings.Contains(err.Error(), "message_id") {
+			t.Fatalf("expected error about message_id validation, got: %v", err)
 		}
 	})
 }

--- a/internal/plugins/http/http_test.go
+++ b/internal/plugins/http/http_test.go
@@ -1172,6 +1172,8 @@ paths:
 			t.Fatalf("expected both literal and parameterized operations to be present")
 		}
 
+		// TODO(#openapi-precedence): remove this once github.com/pb33f/libopenapi-validator fixes path precedence
+		// ordering—the test should pass without forcing the parameterized operation to run first.
 		// Force the parameterized operation to be evaluated before the literal one to simulate the reported bug.
 		validator.entry.operations = []*operationMatcher{paramOp, literalOp}
 


### PR DESCRIPTION
This pull request updates the OpenAPI validation documentation to reflect the switch from `kin-openapi` to `libopenapi-validator`, adds a new section on known issues, and introduces a targeted test for a known path precedence bug in the validator. The most significant changes are grouped below.

**Documentation updates:**

* Updated references in `docs/src/examples/http/openapi-validation.md` to use `libopenapi-validator` instead of `kin-openapi`, clarifying which library is responsible for format detection and error reporting. [[1]](diffhunk://#diff-ffe122fa2213d2c9ed22842456463384a9492361509758f6276adee2f501e59fL16-R16) [[2]](diffhunk://#diff-ffe122fa2213d2c9ed22842456463384a9492361509758f6276adee2f501e59fL61-R75)
* Added a "Known Issues" section to the documentation, describing current limitations and bugs in `libopenapi-validator`, including path precedence problems, unsupported encodings, and incomplete validation features.

**Test coverage for path precedence bug:**

* Added a new OpenAPI spec fixture to `internal/plugins/http/http_test.go` specifically designed to test the path precedence issue between literal and parameterized paths.
* Implemented a test case to verify that, due to the current bug, literal paths can lose precedence to parameterized paths in the validator. The test simulates the bug and asserts that the expected validation error occurs.