### PR TITLE
Add Helm Charts for Rocketship

### DIFF
--- a/.github/scripts/helm_lint.sh
+++ b/.github/scripts/helm_lint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="charts/rocketship"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm is required but not installed" >&2
+  exit 1
+fi
+
+helm lint "$CHART_DIR"
+helm lint "$CHART_DIR" -f "$CHART_DIR/values-minikube.yaml"
+helm lint "$CHART_DIR" -f "$CHART_DIR/values-production.yaml"

--- a/.github/scripts/helm_template_check.sh
+++ b/.github/scripts/helm_template_check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="charts/rocketship"
+RELEASE_NAME="rocketship-test"
+NAMESPACE="rocketship"
+
+render() {
+  helm template "$RELEASE_NAME" "$CHART_DIR" --namespace "$NAMESPACE" "$@"
+}
+
+# Default values
+output=$(render)
+
+# Ensure engine service exposes named ports
+if ! grep -q "name: grpc" <<<"$output"; then
+  echo "grpc port name not found in rendered templates" >&2
+  exit 1
+fi
+if ! grep -q "name: http" <<<"$output"; then
+  echo "http port name not found in rendered templates" >&2
+  exit 1
+fi
+
+# Minikube values should set service type NodePort
+minikube_output=$(render -f "$CHART_DIR/values-minikube.yaml")
+if ! grep -q "type: NodePort" <<<"$minikube_output"; then
+  echo "Expected NodePort service when using values-minikube.yaml" >&2
+  exit 1
+fi
+
+# Production values should include ALB annotations for gRPC
+prod_output=$(render -f "$CHART_DIR/values-production.yaml")
+if ! grep -q "alb.ingress.kubernetes.io/backend-protocol-version: GRPC" <<<"$prod_output"; then
+  echo "Expected GRPC backend annotation in production values" >&2
+  exit 1
+fi
+

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -451,3 +451,19 @@ jobs:
       - name: Run comprehensive MCP integration tests
         run: |
           ./.github/scripts/test-mcp-integration.sh
+  helm:
+    name: Helm Chart Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.14.0
+
+      - name: Helm lint
+        run: ./.github/scripts/helm_lint.sh
+
+      - name: Helm template checks
+        run: ./.github/scripts/helm_template_check.sh

--- a/charts/rocketship/Chart.yaml
+++ b/charts/rocketship/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: rocketship
+description: Rocketship engine and worker Helm chart
+home: https://github.com/rocketship-ai/rocketship
+icon: https://raw.githubusercontent.com/rocketship-ai/rocketship/main/docs/src/assets/transparent.png
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - rocketship
+  - testing
+  - temporal
+sources:
+  - https://github.com/rocketship-ai/rocketship

--- a/charts/rocketship/templates/NOTES.txt
+++ b/charts/rocketship/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Rocketship has been deployed.
+
+Engine endpoint (gRPC): service {{ include "rocketship.engine.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.engine.service.grpcPort }}
+Health endpoint: service {{ include "rocketship.engine.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.engine.service.httpPort }}
+
+Temporal host configured as: {{ .Values.temporal.host }}
+
+To port-forward the engine gRPC endpoint locally:
+  kubectl port-forward svc/{{ include "rocketship.engine.fullname" . }} 7700:{{ .Values.engine.service.grpcPort }}

--- a/charts/rocketship/templates/_helpers.tpl
+++ b/charts/rocketship/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "rocketship.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "rocketship.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "rocketship.name" . -}}
+{{- if eq $name .Release.Name -}}
+{{- $name -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "rocketship.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "rocketship.labels" -}}
+helm.sh/chart: {{ include "rocketship.chart" . }}
+{{ include "rocketship.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "rocketship.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rocketship.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "rocketship.engine.fullname" -}}
+{{- printf "%s-engine" (include "rocketship.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "rocketship.worker.fullname" -}}
+{{- printf "%s-worker" (include "rocketship.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/rocketship/templates/engine-deployment.yaml
+++ b/charts/rocketship/templates/engine-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rocketship.engine.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.engine.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketship.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: engine
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rocketship.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: engine
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: engine
+          image: "{{ .Values.engine.image.repository }}:{{ .Values.engine.image.tag }}"
+          imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
+          env:
+            - name: TEMPORAL_HOST
+              value: {{ .Values.temporal.host | quote }}
+            {{- range .Values.engine.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.engine.service.grpcPort }}
+              protocol: TCP
+            - name: http
+              containerPort: {{ .Values.engine.service.httpPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          {{- with .Values.engine.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.engine.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.engine.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.engine.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/rocketship/templates/engine-deployment.yaml
+++ b/charts/rocketship/templates/engine-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           env:
             - name: TEMPORAL_HOST
               value: {{ .Values.temporal.host | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.temporal.namespace | quote }}
             {{- range .Values.engine.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}

--- a/charts/rocketship/templates/engine-service.yaml
+++ b/charts/rocketship/templates/engine-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rocketship.engine.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+  {{- with .Values.engine.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.engine.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "rocketship.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: engine
+  ports:
+    - name: grpc
+      port: {{ .Values.engine.service.grpcPort }}
+      targetPort: grpc
+    - name: http
+      port: {{ .Values.engine.service.httpPort }}
+      targetPort: http

--- a/charts/rocketship/templates/ingress.yaml
+++ b/charts/rocketship/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rocketship.engine.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "rocketship.engine.fullname" $ }}
+                port:
+                  name: grpc
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/rocketship/templates/worker-deployment.yaml
+++ b/charts/rocketship/templates/worker-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           env:
             - name: TEMPORAL_HOST
               value: {{ .Values.temporal.host | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ .Values.temporal.namespace | quote }}
             {{- range .Values.worker.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}

--- a/charts/rocketship/templates/worker-deployment.yaml
+++ b/charts/rocketship/templates/worker-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rocketship.worker.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketship.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rocketship.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: worker
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          env:
+            - name: TEMPORAL_HOST
+              value: {{ .Values.temporal.host | quote }}
+            {{- range .Values.worker.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/rocketship/values-minikube.yaml
+++ b/charts/rocketship/values-minikube.yaml
@@ -1,0 +1,9 @@
+engine:
+  service:
+    type: NodePort
+    # Allow Kubernetes to allocate node ports automatically. Override if specific ports are required.
+    annotations: {}
+
+worker:
+  replicaCount: 1
+

--- a/charts/rocketship/values-production.yaml
+++ b/charts/rocketship/values-production.yaml
@@ -1,0 +1,15 @@
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+  hosts:
+    - host: rocketship.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+

--- a/charts/rocketship/values.yaml
+++ b/charts/rocketship/values.yaml
@@ -15,9 +15,10 @@ securityContext: {}
 
 temporal:
   # Hostname:port of the Temporal frontend service. The default assumes you
-  # install Temporal into the "temporal" namespace with release name "temporal".
+  # install Temporal into the "rocketship" namespace with release name "temporal".
   # Override as needed or set via --set temporal.host=...
-  host: "temporal-frontend.temporal:7233"
+  host: "temporal-frontend.rocketship:7233"
+  namespace: "default"
 
 engine:
   replicaCount: 1

--- a/charts/rocketship/values.yaml
+++ b/charts/rocketship/values.yaml
@@ -1,0 +1,60 @@
+# Default values for Rocketship Helm chart.
+# This chart deploys the Rocketship engine and worker. A Temporal cluster must
+# already be available and reachable via the configured host.
+
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+temporal:
+  # Hostname:port of the Temporal frontend service. The default assumes you
+  # install Temporal into the "temporal" namespace with release name "temporal".
+  # Override as needed or set via --set temporal.host=...
+  host: "temporal-frontend.temporal:7233"
+
+engine:
+  replicaCount: 1
+  image:
+    repository: rocketshipai/rocketship-engine
+    tag: latest
+    pullPolicy: IfNotPresent
+  env: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  service:
+    type: ClusterIP
+    annotations: {}
+    grpcPort: 7700
+    httpPort: 7701
+
+worker:
+  replicaCount: 1
+  image:
+    repository: rocketshipai/rocketship-worker
+    tag: latest
+    pullPolicy: IfNotPresent
+  env: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: rocketship.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -24,10 +24,15 @@ func main() {
 		logger.Error("TEMPORAL_HOST environment variable is not set")
 		os.Exit(1)
 	}
+	temporalNamespace := os.Getenv("TEMPORAL_NAMESPACE")
+	if temporalNamespace == "" {
+		temporalNamespace = "default"
+	}
 
 	logger.Debug("connecting to temporal", "host", temporalHost)
 	c, err := client.Dial(client.Options{
-		HostPort: temporalHost,
+		HostPort:  temporalHost,
+		Namespace: temporalNamespace,
 	})
 	if err != nil {
 		logger.Error("failed to create temporal client", "error", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rocketship-ai/rocketship/internal/cli"
 	"github.com/rocketship-ai/rocketship/internal/interpreter"
 	"github.com/rocketship-ai/rocketship/internal/plugins"
-	
+
 	// Import plugins to trigger auto-registration
 	_ "github.com/rocketship-ai/rocketship/internal/plugins/agent"
 	_ "github.com/rocketship-ai/rocketship/internal/plugins/browser"
@@ -16,7 +16,7 @@ import (
 	_ "github.com/rocketship-ai/rocketship/internal/plugins/script"
 	_ "github.com/rocketship-ai/rocketship/internal/plugins/sql"
 	_ "github.com/rocketship-ai/rocketship/internal/plugins/supabase"
-	
+
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 )
@@ -31,10 +31,15 @@ func main() {
 		logger.Error("TEMPORAL_HOST environment variable is not set")
 		os.Exit(1)
 	}
+	temporalNamespace := os.Getenv("TEMPORAL_NAMESPACE")
+	if temporalNamespace == "" {
+		temporalNamespace = "default"
+	}
 
 	logger.Debug("connecting to temporal", "host", temporalHost)
 	c, err := client.Dial(client.Options{
-		HostPort: temporalHost,
+		HostPort:  temporalHost,
+		Namespace: temporalNamespace,
 	})
 	if err != nil {
 		logger.Error("failed to create temporal client", "error", err)

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
 MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-rocketship}
-TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-temporal}
+TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-rocketship}
 ROCKETSHIP_NAMESPACE=${ROCKETSHIP_NAMESPACE:-rocketship}
 TEMPORAL_RELEASE=${TEMPORAL_RELEASE:-temporal}
 ROCKETSHIP_RELEASE=${ROCKETSHIP_RELEASE:-rocketship}
 ROCKETSHIP_CHART_PATH=${ROCKETSHIP_CHART_PATH:-charts/rocketship}
+TEMPORAL_WORKFLOW_NAMESPACE=${TEMPORAL_WORKFLOW_NAMESPACE:-default}
+ENGINE_IMAGE_LOCAL=${ENGINE_IMAGE_LOCAL:-rocketship-engine-local}
+WORKER_IMAGE_LOCAL=${WORKER_IMAGE_LOCAL:-rocketship-worker-local}
+LOCAL_IMAGE_TAG=${LOCAL_IMAGE_TAG:-dev}
 
 check_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -38,6 +46,13 @@ if ! helm repo list 2>/dev/null | grep -q "go.temporal.io/helm-charts"; then
 fi
 helm repo update
 
+# Build local Rocketship images inside the Minikube Docker daemon
+echo "Building Rocketship engine and worker images inside Minikube..."
+eval "$(minikube -p "$MINIKUBE_PROFILE" docker-env)"
+docker build -t "${ENGINE_IMAGE_LOCAL}:${LOCAL_IMAGE_TAG}" -f .docker/Dockerfile.engine .
+docker build -t "${WORKER_IMAGE_LOCAL}:${LOCAL_IMAGE_TAG}" -f .docker/Dockerfile.worker .
+eval "$(minikube -p "$MINIKUBE_PROFILE" docker-env --unset)"
+
 # Install Temporal with minimal footprint suitable for minikube
 if ! helm status "$TEMPORAL_RELEASE" -n "$TEMPORAL_NAMESPACE" >/dev/null 2>&1; then
   echo "Installing Temporal (this may take several minutes)..."
@@ -53,6 +68,17 @@ else
   echo "Temporal release $TEMPORAL_RELEASE already installed. Skipping."
 fi
 
+# Ensure Temporal workflow namespace exists
+ADMIN_TOOLS_DEPLOY="${TEMPORAL_RELEASE}-admintools"
+echo "Ensuring Temporal namespace '$TEMPORAL_WORKFLOW_NAMESPACE' exists..."
+if kubectl --namespace "$TEMPORAL_NAMESPACE" rollout status "deployment/$ADMIN_TOOLS_DEPLOY" --timeout=120s >/dev/null 2>&1; then
+  if ! kubectl exec -n "$TEMPORAL_NAMESPACE" "deploy/$ADMIN_TOOLS_DEPLOY" -- temporal operator namespace describe "$TEMPORAL_WORKFLOW_NAMESPACE" >/dev/null 2>&1; then
+    kubectl exec -n "$TEMPORAL_NAMESPACE" "deploy/$ADMIN_TOOLS_DEPLOY" -- temporal operator namespace create --namespace "$TEMPORAL_WORKFLOW_NAMESPACE" --retention 72h || true
+  fi
+else
+  echo "WARNING: admin tools deployment not ready; skipping namespace registration"
+fi
+
 # Determine Temporal frontend host
 TEMPORAL_HOST="${TEMPORAL_RELEASE}-frontend.${TEMPORAL_NAMESPACE}:7233"
 
@@ -62,12 +88,26 @@ if helm status "$ROCKETSHIP_RELEASE" -n "$ROCKETSHIP_NAMESPACE" >/dev/null 2>&1;
   helm upgrade "$ROCKETSHIP_RELEASE" "$ROCKETSHIP_CHART_PATH" \
     --namespace "$ROCKETSHIP_NAMESPACE" --create-namespace \
     --set temporal.host="$TEMPORAL_HOST" \
+    --set temporal.namespace="$TEMPORAL_WORKFLOW_NAMESPACE" \
+    --set engine.image.repository="$ENGINE_IMAGE_LOCAL" \
+    --set engine.image.tag="$LOCAL_IMAGE_TAG" \
+    --set engine.image.pullPolicy=IfNotPresent \
+    --set worker.image.repository="$WORKER_IMAGE_LOCAL" \
+    --set worker.image.tag="$LOCAL_IMAGE_TAG" \
+    --set worker.image.pullPolicy=IfNotPresent \
     --wait
 else
   echo "Installing Rocketship chart..."
   helm install "$ROCKETSHIP_RELEASE" "$ROCKETSHIP_CHART_PATH" \
     --namespace "$ROCKETSHIP_NAMESPACE" --create-namespace \
     --set temporal.host="$TEMPORAL_HOST" \
+    --set temporal.namespace="$TEMPORAL_WORKFLOW_NAMESPACE" \
+    --set engine.image.repository="$ENGINE_IMAGE_LOCAL" \
+    --set engine.image.tag="$LOCAL_IMAGE_TAG" \
+    --set engine.image.pullPolicy=IfNotPresent \
+    --set worker.image.repository="$WORKER_IMAGE_LOCAL" \
+    --set worker.image.tag="$LOCAL_IMAGE_TAG" \
+    --set worker.image.pullPolicy=IfNotPresent \
     --wait
 fi
 
@@ -77,9 +117,12 @@ cat <<SUMMARY
 Temporal namespace:   $TEMPORAL_NAMESPACE (release $TEMPORAL_RELEASE)
 Rocketship namespace: $ROCKETSHIP_NAMESPACE (release $ROCKETSHIP_RELEASE)
 Temporal host used:   $TEMPORAL_HOST
+Temporal workflow namespace: $TEMPORAL_WORKFLOW_NAMESPACE
+Engine image:         ${ENGINE_IMAGE_LOCAL}:${LOCAL_IMAGE_TAG}
+Worker image:         ${WORKER_IMAGE_LOCAL}:${LOCAL_IMAGE_TAG}
 
 To port-forward the Rocketship engine gRPC endpoint:
-  kubectl port-forward -n $ROCKETSHIP_NAMESPACE svc/${ROCKETSHIP_RELEASE}-rocketship-engine 7700:7700
+  kubectl port-forward -n $ROCKETSHIP_NAMESPACE svc/${ROCKETSHIP_RELEASE}-engine 7700:7700
 
 To port-forward the Temporal Frontend:
   kubectl port-forward -n $TEMPORAL_NAMESPACE svc/${TEMPORAL_RELEASE}-frontend 7233:7233

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-rocketship}
+TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-temporal}
+ROCKETSHIP_NAMESPACE=${ROCKETSHIP_NAMESPACE:-rocketship}
+TEMPORAL_RELEASE=${TEMPORAL_RELEASE:-temporal}
+ROCKETSHIP_RELEASE=${ROCKETSHIP_RELEASE:-rocketship}
+ROCKETSHIP_CHART_PATH=${ROCKETSHIP_CHART_PATH:-charts/rocketship}
+
+check_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: $1 is required but not installed." >&2
+    exit 1
+  fi
+}
+
+check_command minikube
+check_command kubectl
+check_command helm
+
+# Start or ensure minikube is running
+if ! minikube status -p "$MINIKUBE_PROFILE" >/dev/null 2>&1; then
+  echo "Starting minikube profile $MINIKUBE_PROFILE..."
+  minikube start -p "$MINIKUBE_PROFILE" --cpus=4 --memory=8192
+else
+  echo "Minikube profile $MINIKUBE_PROFILE already running."
+fi
+
+# Use the correct profile for subsequent kubectl/helm commands
+export MINIKUBE_PROFILE
+kubectl config use-context "$MINIKUBE_PROFILE" >/dev/null 2>&1 || true
+
+# Add Temporal repo if not present
+if ! helm repo list 2>/dev/null | grep -q "go.temporal.io/helm-charts"; then
+  echo "Adding Temporal Helm repository..."
+  helm repo add temporal https://go.temporal.io/helm-charts
+fi
+helm repo update
+
+# Install Temporal with minimal footprint suitable for minikube
+if ! helm status "$TEMPORAL_RELEASE" -n "$TEMPORAL_NAMESPACE" >/dev/null 2>&1; then
+  echo "Installing Temporal (this may take several minutes)..."
+  helm install "$TEMPORAL_RELEASE" temporal/temporal \
+    --namespace "$TEMPORAL_NAMESPACE" --create-namespace \
+    --set server.replicaCount=1 \
+    --set cassandra.config.cluster_size=1 \
+    --set elasticsearch.replicas=1 \
+    --set prometheus.enabled=false \
+    --set grafana.enabled=false \
+    --wait --timeout 15m
+else
+  echo "Temporal release $TEMPORAL_RELEASE already installed. Skipping."
+fi
+
+# Determine Temporal frontend host
+TEMPORAL_HOST="${TEMPORAL_RELEASE}-frontend.${TEMPORAL_NAMESPACE}:7233"
+
+# Install/upgrade Rocketship chart
+if helm status "$ROCKETSHIP_RELEASE" -n "$ROCKETSHIP_NAMESPACE" >/dev/null 2>&1; then
+  echo "Upgrading Rocketship chart..."
+  helm upgrade "$ROCKETSHIP_RELEASE" "$ROCKETSHIP_CHART_PATH" \
+    --namespace "$ROCKETSHIP_NAMESPACE" --create-namespace \
+    --set temporal.host="$TEMPORAL_HOST" \
+    --wait
+else
+  echo "Installing Rocketship chart..."
+  helm install "$ROCKETSHIP_RELEASE" "$ROCKETSHIP_CHART_PATH" \
+    --namespace "$ROCKETSHIP_NAMESPACE" --create-namespace \
+    --set temporal.host="$TEMPORAL_HOST" \
+    --wait
+fi
+
+echo "Deployment complete!"
+echo
+cat <<SUMMARY
+Temporal namespace:   $TEMPORAL_NAMESPACE (release $TEMPORAL_RELEASE)
+Rocketship namespace: $ROCKETSHIP_NAMESPACE (release $ROCKETSHIP_RELEASE)
+Temporal host used:   $TEMPORAL_HOST
+
+To port-forward the Rocketship engine gRPC endpoint:
+  kubectl port-forward -n $ROCKETSHIP_NAMESPACE svc/${ROCKETSHIP_RELEASE}-rocketship-engine 7700:7700
+
+To port-forward the Temporal Frontend:
+  kubectl port-forward -n $TEMPORAL_NAMESPACE svc/${TEMPORAL_RELEASE}-frontend 7233:7233
+SUMMARY


### PR DESCRIPTION
This pull request introduces a Helm chart for deploying the Rocketship engine and worker, along with CI/CD integration for Helm chart validation and improvements to the build and linting workflow. The most important changes are grouped below.

**Helm Chart Introduction and Configuration:**

* Added a new Helm chart under `charts/rocketship` with templates for engine and worker deployments, services, ingress, and helper templates, plus default and environment-specific values files (`values.yaml`, `values-minikube.yaml`, `values-production.yaml`). This enables standardized Kubernetes deployments for Rocketship. [[1]](diffhunk://#diff-5dd2480c0293c7e5ddfebc24ca4df1869dfe59452d479d3ce94ea7001a97a8bcR1-R14) [[2]](diffhunk://#diff-2590664aafa53381fc7b78e1398db673959482411113f50608dadab8438f6f65R1-R76) [[3]](diffhunk://#diff-1ed83151cf31fa28b9b2a9158b9dbb2de1262f48dc26209d5d40c73bd0369336R1-R23) [[4]](diffhunk://#diff-9aff681061d913561d966a00c2b2ae37ddef9da1e4362dbd1964ffe5de72cd7bR1-R35) [[5]](diffhunk://#diff-f71a147d45d6fbcfad56a2703ba03fbfd98e23776dc842d1e669378562ce3f97R1-R61) [[6]](diffhunk://#diff-3db25afc959c300051429b2d1bd673808a644452cf4e23203dbb3b3d8e353a50R1-R42) [[7]](diffhunk://#diff-ab52b23570ae1197855a7eb66a62c0255c413e008d018de76f5d0d7da919d2b8R1-R9) [[8]](diffhunk://#diff-6bd4f7c3f6bae8ca8c86dfbfa1cec8c720dceb89dcd9f28556f2202f222b9f4eR1-R61) [[9]](diffhunk://#diff-2b382001a29415a8eaa023b8f37e2536aef1a5fd7b2b95c1956edbc4fa0e6c09R1-R9) [[10]](diffhunk://#diff-a116904d3cc49204dd1d1d53bf35426988da94451a898609a71acdcbacef7218R1-R15)

**CI/CD and Workflow Enhancements:**

* Added new GitHub Actions jobs to run Helm linting and template checks, ensuring chart validity and correct configuration for different environments.
* Introduced shell scripts `.github/scripts/helm_lint.sh` and `.github/scripts/helm_template_check.sh` to automate Helm chart validation and template rendering checks in CI. [[1]](diffhunk://#diff-3e142bda2935e5c166fd70429d166830d351fdfbbe0ffd603472770c22103ff0R1-R13) [[2]](diffhunk://#diff-b234675df73b2ab3b3b5e86f03a4aa1494f4d703c9c7425eb083d10d5a8ea818R1-R38)

**Build and Lint Workflow Improvements:**

* Updated the `Makefile` to add targets for Helm linting and template checks, and refactored the lint and test targets to include these new steps. This ensures Helm chart validation is part of local and CI workflows. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L26-R26) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R59-R66) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L84-R104)

**Application Configuration Updates:**

* Modified both engine and worker startup code to support a configurable Temporal namespace via the `TEMPORAL_NAMESPACE` environment variable, defaulting to "default" if not set. This improves compatibility with different Temporal cluster setups. [[1]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R27-R35) [[2]](diffhunk://#diff-e86845c9856930590fe7e443c15177fcc600404acbd65f658b02d6fee12aac5dR34-R42)