### PR TITLE
Add Templates For OIDC Web UI Auth Flow

### DIFF
--- a/.github/scripts/helm_template_check.sh
+++ b/.github/scripts/helm_template_check.sh
@@ -36,3 +36,13 @@ if ! grep -qiE "ingress\.kubernetes\.io/backend-protocol(-version)?:[[:space:]]*
   exit 1
 fi
 
+# OIDC web preset should render oauth2-proxy deployment and env markers
+oidc_output=$(render -f "$CHART_DIR/values-oidc-web.yaml")
+if ! grep -q "oauth2-proxy" <<<"$oidc_output"; then
+  echo "Expected oauth2-proxy resources in values-oidc-web.yaml render" >&2
+  exit 1
+fi
+if ! grep -q "OAUTH2_PROXY_PROVIDER" <<<"$oidc_output"; then
+  echo "Expected OIDC environment variables in oauth2-proxy deployment" >&2
+  exit 1
+fi

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -238,10 +238,10 @@ Optional E2E (follow‑up)
 
 ## Ingress With OIDC at ALB (For Web) vs gRPC For CLI
 
-Ingress pattern: ALB can enforce OIDC at the edge using annotations (issuer, authorize/token/userinfo endpoints, client secret), maintaining a browser session via `AWSELBAuthSessionCookie`. This works well for web UIs and HTTP routes. However, OIDC at ALB is not compatible with raw gRPC clients (the redirect/302‑based flow breaks gRPC). Therefore:
+Ingress pattern: ALB can enforce OIDC at the edge using annotations (issuer, authorize/token/userinfo endpoints, client secret), maintaining a browser session via `AWSELBAuthSessionCookie`. This works well for web UIs and HTTP routes. However, OIDC at ALB is not compatible with raw gRPC clients (the redirect/302-based flow breaks gRPC). Therefore:
 
 - Use OIDC at ALB for web/HTTP endpoints (future Rocketship web UI, simple status pages).
-- Keep the Engine gRPC ingress separate and protect gRPC via application‑level auth (token or JWT validated by the engine). This is CLI‑friendly and avoids ALB redirect complexity.
+- Keep the Engine gRPC ingress separate and protect gRPC via application-level auth (token or JWT validated by the engine). This is CLI-friendly and avoids ALB redirect complexity.
 
 The chart will ship two presets:
 - `values-grpc.yaml` — gRPC ingress with `alb.ingress.kubernetes.io/backend-protocol-version: GRPC`, service port named `grpc`.
@@ -249,3 +249,18 @@ The chart will ship two presets:
 
 RBAC Note
 - RBAC is out of scope for this epic. Plan to add role/permission enforcement once orgs/users are fully modeled and JWTs are in place (v2).
+
+---
+
+## Post-Epic Naming Alignment (Managed Cloud & Self-Hosted)
+
+When the v1 workstream (PRs 1–8) completes and we begin prepping the managed cloud rollout:
+
+- **Web UI hostnames**
+  - Self-hosted reference environments: migrate the web ingress to become the primary apex host (`globalbank.rocketship.sh`).
+  - Managed cloud environment: serve the UI from `app.rocketship.sh`.
+- **CLI / gRPC hostnames**
+  - Self-hosted reference environments: move the gRPC ingress to `cli.globalbank.rocketship.sh` (profiles and docs must be updated accordingly).
+  - Managed cloud environment: expose the gRPC endpoint at `cli.rocketship.sh`.
+
+This hostname swap is intentionally deferred until after PR 8 so the current validation work stays stable. Capture it as a dedicated follow-up task that updates Helm values, DNS guidance, documentation, and profile examples in one pass.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -14,10 +14,10 @@ This plan delivers a production‑ready, Kubernetes‑hostable Rocketship server
 ## Outcome Overview
 
 - Users deploy Engine + Worker on Kubernetes via Helm.
-- ALB/NLB Ingress supported; HTTP health endpoint exposed; gRPC over TLS supported.
+- Ingress controllers (NGINX, cloud load balancers) supported; HTTP health endpoint exposed; gRPC over TLS supported.
 - CLI can connect to `grpcs://` endpoints via profiles or `--engine`.
 - Server discovery tells the CLI which auth mode is active; CLI adapts.
-- Optional enterprise ingress with OIDC at ALB for web endpoints; CLI remains token/JWT‑based.
+- Optional ingress with OIDC (via oauth2-proxy) for web endpoints; CLI remains token/JWT‑based.
 
 
 ## Test Resources (For Manual/E2E Verification)
@@ -26,12 +26,12 @@ These resources are available for manual validation where applicable:
 
 - Domain/TLS: `globalbank.rocketship.sh` with a ZeroSSL certificate
   - Use to verify Ingress TLS and gRPC over TLS.
-  - Create a Kubernetes TLS secret (e.g., `globalbank-tls`) with the ZeroSSL cert and key.
+  - Create a Kubernetes TLS secret (e.g., `globalbank-rocketship-tls`) with the ZeroSSL cert and key.
   - Point DNS for `globalbank.rocketship.sh` (or subdomain) to the ingress/ALB.
 
 - IdP: Auth0 tenant/account
   - Use to validate OIDC in two places when we reach them:
-    1) OIDC at ALB for web endpoints (PR 4, optional)
+    1) OIDC at ingress for web endpoints (PR 4, optional)
     2) OIDC Device Flow for CLI login (PR 7, optional/phase‑next)
 
 
@@ -86,7 +86,7 @@ Changes
   - `values-minikube.yaml`, `values-production.yaml`
 
 Manual test prerequisites (optional)
-- If validating TLS with a real hostname, create a TLS secret `globalbank-tls` from the ZeroSSL cert and set `ingress.tls.secretName=globalbank-tls` in values.
+- If validating TLS with a real hostname, create a TLS secret `globalbank-rocketship-tls` from the ZeroSSL cert and set `ingress.tls.secretName=globalbank-rocketship-tls` in values.
 - Create a DNS record for `globalbank.rocketship.sh` (or a subdomain) pointing to the ingress/ALB/NLB.
 
 Tests (templating)
@@ -99,26 +99,25 @@ CI integration
 
 ---
 
-## PR 4 — Ingress Presets (gRPC and OIDC‑at‑ALB for Web)
+## PR 4 — Ingress Presets (gRPC baseline + optional OIDC web)
 
 What it accomplishes
-- Provides production values for two common ingress patterns:
-  1) gRPC over ALB/NLB for the Engine API
-  2) OIDC at ALB for web/HTTP endpoints (not for CLI gRPC)
+- Document the existing NGINX gRPC values as the production baseline (DigitalOcean-ready).
+- Provide an additional values file for enabling OIDC at the ingress for HTTP/web endpoints via oauth2-proxy (leaves gRPC untouched).
 
 Changes
-- `helm/rocketship/values-grpc.yaml`: includes `alb.ingress.kubernetes.io/backend-protocol-version: GRPC` and names service port `grpc`.
-- `helm/rocketship/values-oidc-web.yaml`: adds OIDC annotations for browser traffic; scopes, cookie, session timeout; targets HTTP endpoints only (e.g., future web UI, health page).
+- `charts/rocketship/values-production.yaml`: clarify it targets NGINX gRPC ingress (already in place).
+- `charts/rocketship/values-oidc-web.yaml`: add oauth2-proxy deployment and NGINX annotations for OIDC (issuer, client ID/secret, scopes, cookie name).
 
 Tests (templating)
-- Extend `helm_template_check.sh` to assert presence of ALB annotations and correct port naming in each preset.
+- Update `helm_template_check.sh` to render `values-oidc-web.yaml` and assert OIDC annotations and oauth2-proxy env are present.
 
 CI integration
-- Include these values in the Helm chart workflow matrix.
+- Reuse the Helm template check workflow; add the new values file to the matrix.
 
 Manual test prerequisites (optional)
-- Use the `globalbank.rocketship.sh` certificate via `globalbank-tls` to validate HTTPS.
-- For OIDC at ALB (web): configure an Auth0 application and supply ALB OIDC annotations with the Auth0 issuer and endpoints; verify browser flow succeeds and `/healthz` is accessible after authentication.
+- Use the `globalbank.rocketship.sh` certificate via `globalbank-rocketship-tls`.
+- Configure oauth2-proxy with Auth0 (or other IdP) credentials and verify browser login gates `/healthz` (gRPC remains token-based in later PRs).
 
 ---
 

--- a/charts/rocketship/templates/_helpers.tpl
+++ b/charts/rocketship/templates/_helpers.tpl
@@ -40,3 +40,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "rocketship.worker.fullname" -}}
 {{- printf "%s-worker" (include "rocketship.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "rocketship.webProxy.fullname" -}}
+{{- printf "%s-web-oauth2-proxy" (include "rocketship.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/rocketship/templates/web-ingress.yaml
+++ b/charts/rocketship/templates/web-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.web.enabled .Values.web.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rocketship.webProxy.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web-oauth2-proxy
+  {{- with .Values.web.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.web.ingress.className }}
+  ingressClassName: {{ .Values.web.ingress.className }}
+  {{- end }}
+  {{- if .Values.web.ingress.tls }}
+  tls:
+    {{- toYaml .Values.web.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.web.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "rocketship.webProxy.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/rocketship/templates/web-oauth2-proxy-deployment.yaml
+++ b/charts/rocketship/templates/web-oauth2-proxy-deployment.yaml
@@ -35,6 +35,7 @@ spec:
           {{- $upstream := .Values.web.oauth2Proxy.upstreamOverride | default $defaultUpstream }}
           args:
             - "--http-address=0.0.0.0:{{ .Values.web.oauth2Proxy.service.port }}"
+            - "--https-address=:0"
             - "--upstream={{ $upstream }}"
             {{- range .Values.web.oauth2Proxy.extraArgs }}
             - {{ . | quote }}

--- a/charts/rocketship/templates/web-oauth2-proxy-deployment.yaml
+++ b/charts/rocketship/templates/web-oauth2-proxy-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.web.enabled .Values.web.oauth2Proxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rocketship.webProxy.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web-oauth2-proxy
+spec:
+  replicas: {{ .Values.web.oauth2Proxy.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketship.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: web-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rocketship.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: web-oauth2-proxy
+        {{- with .Values.web.oauth2Proxy.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.web.oauth2Proxy.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: "{{ .Values.web.oauth2Proxy.image.repository }}:{{ .Values.web.oauth2Proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.web.oauth2Proxy.image.pullPolicy }}
+          {{- $defaultUpstream := printf "http://%s:%d" (include "rocketship.engine.fullname" .) (int .Values.engine.service.httpPort) }}
+          {{- $upstream := .Values.web.oauth2Proxy.upstreamOverride | default $defaultUpstream }}
+          args:
+            - "--http-address=0.0.0.0:{{ .Values.web.oauth2Proxy.service.port }}"
+            - "--upstream={{ $upstream }}"
+            {{- range .Values.web.oauth2Proxy.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.oauth2Proxy.service.port }}
+          {{- if .Values.web.oauth2Proxy.env }}
+          env:
+            {{- range .Values.web.oauth2Proxy.env }}
+            - name: {{ .name }}
+              {{- if hasKey . "value" }}
+              value: {{ .value | quote }}
+              {{- else if hasKey . "valueFrom" }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.web.oauth2Proxy.envFrom }}
+          envFrom:
+            {{- toYaml .Values.web.oauth2Proxy.envFrom | nindent 12 }}
+          {{- end }}
+          {{- with .Values.web.oauth2Proxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.web.oauth2Proxy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.oauth2Proxy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.web.oauth2Proxy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/rocketship/templates/web-oauth2-proxy-service.yaml
+++ b/charts/rocketship/templates/web-oauth2-proxy-service.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.web.enabled .Values.web.oauth2Proxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rocketship.webProxy.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web-oauth2-proxy
+spec:
+  type: {{ .Values.web.oauth2Proxy.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "rocketship.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: web-oauth2-proxy
+  ports:
+    - name: http
+      port: {{ .Values.web.oauth2Proxy.service.port }}
+      targetPort: http
+{{- end }}

--- a/charts/rocketship/values-oidc-web.yaml
+++ b/charts/rocketship/values-oidc-web.yaml
@@ -1,0 +1,71 @@
+# Example values for enabling oauth2-proxy in front of the Rocketship web endpoints
+# This configuration assumes:
+# - An Auth0 (or compatible OIDC) application configured for the Rocketship web UI
+# - A Kubernetes secret named `oauth2-proxy-credentials` with keys:
+#     clientID          -> OAuth client ID (plain text)
+#     clientSecret      -> OAuth client secret
+#     cookieSecret      -> 32-byte random string, base64 encoded (use `openssl rand -base64 32`)
+# - The Rocketship engine service will serve HTTP traffic (health/UI) on port 7701
+
+web:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    hosts:
+      - host: app.globalbank.rocketship.sh
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: globalbank-rocketship-tls
+        hosts:
+          - app.globalbank.rocketship.sh
+  oauth2Proxy:
+    enabled: true
+    replicaCount: 1
+    # Set to empty to let the chart route requests to the engine HTTP port (7701)
+    upstreamOverride: ""
+    extraArgs:
+      - --cookie-name=_rocketship_auth
+      - --cookie-secure=true
+      - --cookie-samesite=lax
+      - --scope=openid profile email
+      - --email-domain=*
+      - --skip-provider-button=true
+    env:
+      - name: OAUTH2_PROXY_PROVIDER
+        value: oidc
+      - name: OAUTH2_PROXY_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-credentials
+            key: clientID
+      - name: OAUTH2_PROXY_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-credentials
+            key: clientSecret
+      - name: OAUTH2_PROXY_COOKIE_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-credentials
+            key: cookieSecret
+      - name: OAUTH2_PROXY_REDIRECT_URL
+        value: https://app.globalbank.rocketship.sh/oauth2/callback
+      - name: OAUTH2_PROXY_OIDC_ISSUER_URL
+        value: https://YOUR_AUTH0_DOMAIN/    # e.g. https://rocketship-demo.us.auth0.com/
+      - name: OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL
+        value: "false"
+      - name: OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER
+        value: "true"
+      - name: OAUTH2_PROXY_SET_AUTHORIZATION_HEADER
+        value: "true"
+      - name: OAUTH2_PROXY_SET_XAUTHREQUEST
+        value: "true"
+      - name: OAUTH2_PROXY_FORCE_HTTPS
+        value: "true"

--- a/charts/rocketship/values-oidc-web.yaml
+++ b/charts/rocketship/values-oidc-web.yaml
@@ -4,7 +4,7 @@
 # - A Kubernetes secret named `oauth2-proxy-credentials` with keys:
 #     clientID          -> OAuth client ID (plain text)
 #     clientSecret      -> OAuth client secret
-#     cookieSecret      -> 32-byte random string, base64 encoded (use `openssl rand -base64 32`)
+#     cookieSecret      -> 32-byte random string, base64 encoded (e.g. `python -c "import secrets, base64; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())"`)
 # - The Rocketship engine service will serve HTTP traffic (health/UI) on port 7701
 
 web:
@@ -58,7 +58,7 @@ web:
       - name: OAUTH2_PROXY_REDIRECT_URL
         value: https://app.globalbank.rocketship.sh/oauth2/callback
       - name: OAUTH2_PROXY_OIDC_ISSUER_URL
-        value: https://YOUR_AUTH0_DOMAIN/    # e.g. https://rocketship-demo.us.auth0.com/
+        value: https://dev-0ankenxegmh7xfjm.us.auth0.com/ # e.g. https://rocketship-demo.us.auth0.com/
       - name: OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL
         value: "false"
       - name: OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER
@@ -68,4 +68,6 @@ web:
       - name: OAUTH2_PROXY_SET_XAUTHREQUEST
         value: "true"
       - name: OAUTH2_PROXY_FORCE_HTTPS
-        value: "true"
+        value: "false"
+      - name: OAUTH2_PROXY_HTTPS_ADDRESS
+        value: ":0"

--- a/charts/rocketship/values.yaml
+++ b/charts/rocketship/values.yaml
@@ -59,3 +59,38 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
+
+web:
+  enabled: false
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  oauth2Proxy:
+    enabled: false
+    replicaCount: 1
+    image:
+      repository: quay.io/oauth2-proxy/oauth2-proxy
+      tag: v7.6.0
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 4180
+    upstreamOverride: ""
+    extraArgs:
+      - --cookie-secure=true
+      - --cookie-samesite=lax
+      - --set-authorization-header=true
+      - --pass-authorization-header=true
+      - --pass-access-token=true
+      - --set-xauthrequest=true
+    env: []
+    envFrom: []
+    podAnnotations: {}
+    podLabels: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}

--- a/charts/rocketship/values.yaml
+++ b/charts/rocketship/values.yaml
@@ -80,6 +80,8 @@ web:
       port: 4180
     upstreamOverride: ""
     extraArgs:
+      - --http-address=0.0.0.0:{{ .Values.web.oauth2Proxy.service.port }}
+      - --https-address=:0
       - --cookie-secure=true
       - --cookie-samesite=lax
       - --set-authorization-header=true

--- a/docs/src/deploy-on-your-cloud.md
+++ b/docs/src/deploy-on-your-cloud.md
@@ -20,6 +20,7 @@ Both Rocketship services require the Temporal frontend host and namespace; every
 | --- | --- | --- |
 | Local iteration | [Run on Minikube](deploy/minikube.md) | Single script (`scripts/install-minikube.sh`) that starts Minikube, installs Temporal, builds local engine/worker images, and deploys the Rocketship chart. Great for fast feedback and integration testing inside CI. |
 | Production-ready proof of concept | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md) | Walks through preparing a managed cluster, wiring an NGINX ingress with TLS, publishing custom images to DigitalOcean Container Registry, and installing the Rocketship + Temporal Helm releases. |
+| Web UI with OIDC front-door | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md#enable-oidc-for-the-web-ui) | Layer oauth2-proxy + NGINX annotations using `values-oidc-web.yaml`, so authenticated users reach the web endpoints via Auth0/Okta while gRPC remains unaffected. |
 
 > Looking for another cloud? The DigitalOcean flow covers all building blocks: registry authentication, TLS secrets, ingress, and chart overrides. Adapt the same pattern for EKS, GKE, AKS, or on-prem clusters by swapping provider-specific commands.
 
@@ -29,4 +30,4 @@ Both Rocketship services require the Temporal frontend host and namespace; every
 - Run suites with `rocketship run --engine`. When profiles are active, the CLI resolves the engine address automatically.
 - Expose Prometheus/Grafana, RBAC, and authentication once the core stack is stable (tracked for future epics).
 
-Continue with one of the guides above to stand up Rocketship in your environment.
+Once the core stack is running, you can optionally apply the OIDC preset to front any HTTP/UI endpoints with your IdP before traffic reaches Rocketship.

--- a/docs/src/deploy-on-your-cloud.md
+++ b/docs/src/deploy-on-your-cloud.md
@@ -20,7 +20,7 @@ Both Rocketship services require the Temporal frontend host and namespace; every
 | --- | --- | --- |
 | Local iteration | [Run on Minikube](deploy/minikube.md) | Single script (`scripts/install-minikube.sh`) that starts Minikube, installs Temporal, builds local engine/worker images, and deploys the Rocketship chart. Great for fast feedback and integration testing inside CI. |
 | Production-ready proof of concept | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md) | Walks through preparing a managed cluster, wiring an NGINX ingress with TLS, publishing custom images to DigitalOcean Container Registry, and installing the Rocketship + Temporal Helm releases. |
-| Web UI with OIDC front-door | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md#enable-oidc-for-the-web-ui) | Layer oauth2-proxy + NGINX annotations using `values-oidc-web.yaml`, so authenticated users reach the web endpoints via Auth0/Okta while gRPC remains unaffected. |
+| Web UI with OIDC front-door | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md#7-enable-oidc-for-the-web-ui-optional) | Layer oauth2-proxy + NGINX annotations using `values-oidc-web.yaml`, fronting `app.globalbank.rocketship.sh` while gRPC traffic stays on `globalbank.rocketship.sh`. |
 
 > Looking for another cloud? The DigitalOcean flow covers all building blocks: registry authentication, TLS secrets, ingress, and chart overrides. Adapt the same pattern for EKS, GKE, AKS, or on-prem clusters by swapping provider-specific commands.
 

--- a/docs/src/deploy/digitalocean.md
+++ b/docs/src/deploy/digitalocean.md
@@ -144,7 +144,36 @@ kubectl get pods -n rocketship
 
 `rocketship-engine` and `rocketship-worker` should report `READY 1/1`. Temporal services may restart once while Cassandra and Elasticsearch initialise—that is expected.
 
-## 7. Point DNS at the Load Balancer
+## 7. Enable OIDC for the Web UI (optional)
+
+If you want browser users to authenticate via Auth0/Okta before reaching Rocketship’s HTTP endpoints, layer oauth2-proxy in front of the engine’s HTTP port:
+
+1. **Create the credentials secret** (keys consumed by the preset):
+   ```bash
+   kubectl create secret generic oauth2-proxy-credentials \
+     --namespace rocketship \
+     --from-literal=clientID=YOUR_AUTH0_CLIENT_ID \
+     --from-literal=clientSecret=YOUR_AUTH0_CLIENT_SECRET \
+     --from-literal=cookieSecret=$(openssl rand -base64 32)
+   ```
+
+2. **Review `charts/rocketship/values-oidc-web.yaml`:**
+   - Set `OAUTH2_PROXY_OIDC_ISSUER_URL` to your Auth0 domain (e.g. `https://rocketship-demo.us.auth0.com/`).
+   - Update `OAUTH2_PROXY_REDIRECT_URL` to match the web hostname (`https://app.globalbank.rocketship.sh/oauth2/callback`).
+   - Adjust hosts/TLS to match your ingress.
+
+3. **Apply the preset alongside the existing gRPC values:**
+   ```bash
+   helm upgrade --install rocketship charts/rocketship \
+     --namespace rocketship \
+     -f charts/rocketship/values-production.yaml \
+     -f charts/rocketship/values-oidc-web.yaml \
+     --wait
+   ```
+
+4. **Verify the flow:** hitting `https://app.globalbank.rocketship.sh` should redirect to Auth0. After login you should see the proxied Rocketship health page (`/healthz`). gRPC traffic remains on `globalbank.rocketship.sh:7700` and will use token/device auth once implemented.
+
+## 8. Point DNS at the Load Balancer
 
 Retrieve the ingress address and configure an A record for your domain:
 
@@ -160,7 +189,7 @@ For example, the ingress might resolve to `104.248.110.90`. Create an A record s
 
 Propagation is usually near-immediate within DigitalOcean DNS but may take longer with external registrars.
 
-## 8. Smoke Test the Endpoint
+## 9. Smoke Test the Endpoint
 
 The Rocketship health endpoint answers gRPC, so an HTTPS request returns `415` with `application/grpc`, which confirms end-to-end TLS:
 
@@ -187,7 +216,7 @@ rocketship list    # Should connect through TLS without --engine
 
 If you see a `connection refused` message against `127.0.0.1:7700`, ensure you are running a CLI build that includes the profile resolution fixes introduced in PR #2.
 
-## 9. Updating the Deployment
+## 10. Updating the Deployment
 
 1. Rebuild and push the images with the same tag (or bump the `TAG`).
 2. Run `helm upgrade rocketship charts/rocketship ...` with the updated values.
@@ -197,7 +226,7 @@ If you see a `connection refused` message against `127.0.0.1:7700`, ensure you a
    kubectl rollout status deploy/rocketship-worker -n rocketship
    ```
 
-## 10. Troubleshooting Tips
+## 11. Troubleshooting Tips
 
 - `CrashLoopBackOff` with `exec /bin/engine: exec format error` indicates the image was built for the wrong architecture. Rebuild with `--platform linux/amd64`.
 - If the worker logs show `Namespace <name> is not found`, rerun the Temporal namespace creation step and verify `temporal.namespace` in the Helm values matches.


### PR DESCRIPTION
This pull request introduces support for OIDC authentication for Rocketship web endpoints using oauth2-proxy, with a new Helm values preset and corresponding chart templates. It clarifies the recommended ingress setup for both gRPC and web traffic, updates documentation for deploying with OIDC, and aligns naming conventions for TLS secrets and hostnames. The changes are grouped below by theme.

**Helm Chart Enhancements for OIDC Web Ingress:**

* Added new templates for deploying `oauth2-proxy` (`web-oauth2-proxy-deployment.yaml`, `web-oauth2-proxy-service.yaml`, and `web-ingress.yaml`) to front Rocketship web endpoints with OIDC authentication. These are enabled via the new `web.oauth2Proxy` values. (`[[1]](diffhunk://#diff-e04ff4b55d9fb105135f93b31d30b9b4882bef4ceb334a497ac9b22320499bc4R1-R78)`, `[[2]](diffhunk://#diff-b9cb55d720327cacef0de0eddcdaae312ecc9968e817e4c13ed65df138bee3a0R1-R19)`, `[[3]](diffhunk://#diff-114c1de7e36cef527ed6505b6f5470cc497ee32d3356e1597344b21ec7a4c14bR1-R36)`)
* Introduced the `rocketship.webProxy.fullname` helper in `_helpers.tpl` for consistent naming of oauth2-proxy resources. (`[charts/rocketship/templates/_helpers.tplR43-R46](diffhunk://#diff-3db25afc959c300051429b2d1bd673808a644452cf4e23203dbb3b3d8e353a50R43-R46)`)
* Added `values-oidc-web.yaml` example preset for enabling oauth2-proxy with OIDC, including required environment variables, annotations, and TLS settings. (`[charts/rocketship/values-oidc-web.yamlR1-R73](diffhunk://#diff-132470159df58840bd80420cb416bfbad622465e66f12f125b63fd65729c5855R1-R73)`)
* Extended the main chart `values.yaml` to support configuration of web ingress and oauth2-proxy deployment. (`[charts/rocketship/values.yamlR62-R98](diffhunk://#diff-6bd4f7c3f6bae8ca8c86dfbfa1cec8c720dceb89dcd9f28556f2202f222b9f4eR62-R98)`)

**Testing & Validation:**

* Updated `helm_template_check.sh` to validate that rendering with `values-oidc-web.yaml` produces the expected oauth2-proxy resources and OIDC environment markers. (`[.github/scripts/helm_template_check.shR39-R48](diffhunk://#diff-b234675df73b2ab3b3b5e86f03a4aa1494f4d703c9c7425eb083d10d5a8ea818R39-R48)`)

**Documentation Updates:**

* Updated `MASTER_PLAN.md` to clarify ingress patterns: NGINX gRPC ingress as baseline, with optional OIDC web ingress via oauth2-proxy. Adjusted references to TLS secret naming and provided step-by-step instructions for enabling OIDC. Added a post-epic section for future hostname alignment between self-hosted and managed cloud environments. (`[[1]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L17-R20)`, `[[2]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L29-R34)`, `[[3]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L89-R89)`, `[[4]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L102-R120)`, `[[5]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L242-R266)`)
* Updated deployment documentation (`deploy-on-your-cloud.md`, `deploy/digitalocean.md`) to include instructions for enabling OIDC on the web UI, creating the credentials secret, and updating TLS secret usage. (`[[1]](diffhunk://#diff-cf1cfcec6f9a94057796749e84e5727e213090778640a3c29e3c8cc4e3475f43R23)`, `[[2]](diffhunk://#diff-cf1cfcec6f9a94057796749e84e5727e213090778640a3c29e3c8cc4e3475f43L32-R33)`, `[[3]](diffhunk://#diff-3bb6a8063cc238ff0fa7a8eb662336b183fc8fd668bb8d0018d2d4abb6ffb5aeL64-R74)`, `[[4]](diffhunk://#diff-3bb6a8063cc238ff0fa7a8eb662336b183fc8fd668bb8d0018d2d4abb6ffb5aeL147-R177)`)

**Configuration and Naming Alignment:**

* Standardized TLS secret name to `globalbank-rocketship-tls` across documentation and chart values for consistency. (`[[1]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L29-R34)`, `[[2]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L89-R89)`, `[[3]](diffhunk://#diff-3bb6a8063cc238ff0fa7a8eb662336b183fc8fd668bb8d0018d2d4abb6ffb5aeL64-R74)`)

---

These changes collectively enable secure OIDC authentication for browser-based access to Rocketship web endpoints, while keeping gRPC traffic and CLI authentication separate and unaffected.