### PR TITLE
Add token authentication for the engine

### DIFF
--- a/cmd/engine/main_test.go
+++ b/cmd/engine/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadEngineTokenFromEnv(t *testing.T) {
+	t.Setenv("ROCKETSHIP_ENGINE_TOKEN", " secret-token ")
+	token, err := loadEngineToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "secret-token" {
+		t.Fatalf("expected trimmed token, got %q", token)
+	}
+}
+
+func TestLoadEngineTokenFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token.txt")
+	if err := os.WriteFile(path, []byte(" file-token\n"), 0600); err != nil {
+		t.Fatalf("failed to write token file: %v", err)
+	}
+	t.Setenv("ROCKETSHIP_ENGINE_TOKEN_FILE", path)
+	token, err := loadEngineToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "file-token" {
+		t.Fatalf("expected trimmed token from file, got %q", token)
+	}
+}
+
+func TestLoadEngineTokenFileEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(path, []byte("\n"), 0600); err != nil {
+		t.Fatalf("failed to write token file: %v", err)
+	}
+	t.Setenv("ROCKETSHIP_ENGINE_TOKEN_FILE", path)
+	if _, err := loadEngineToken(); err == nil {
+		t.Fatal("expected error for empty token file")
+	}
+}

--- a/docs/src/deploy-on-your-cloud.md
+++ b/docs/src/deploy-on-your-cloud.md
@@ -27,6 +27,7 @@ Both Rocketship services require the Temporal frontend host and namespace; every
 ## After Deployment
 
 - Use `rocketship profile create` and `rocketship profile use` to store the engine endpoint (`grpcs://…`) and default to TLS where appropriate.
+- Inject a secret token into the engine (`ROCKETSHIP_ENGINE_TOKEN`) and export the same value as `ROCKETSHIP_TOKEN` in the CLI/CI environment so gRPC calls are authenticated.
 - Run suites with `rocketship run --engine`. When profiles are active, the CLI resolves the engine address automatically.
 - Expose Prometheus/Grafana, RBAC, and authentication once the core stack is stable (tracked for future epics).
 

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -83,6 +83,9 @@ func runGet(cmd *cobra.Command, runID string, flags *GetFlags) error {
 		RunId: runID,
 	})
 	if err != nil {
+		if wrapped := translateAuthError("failed to get run", err); wrapped != nil {
+			return wrapped
+		}
 		return fmt.Errorf("failed to get run: %w", err)
 	}
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -120,6 +120,9 @@ func runList(cmd *cobra.Command, flags *ListFlags) error {
 	// Call ListRuns
 	resp, err := client.client.ListRuns(ctx, req)
 	if err != nil {
+		if wrapped := translateAuthError("failed to list runs", err); wrapped != nil {
+			return wrapped
+		}
 		return fmt.Errorf("failed to list runs: %w", err)
 	}
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -309,6 +309,9 @@ func displayRecentRuns(client *EngineClient) error {
 
 	resp, err := client.client.ListRuns(ctx, req)
 	if err != nil {
+		if wrapped := translateAuthError("failed to list recent runs", err); wrapped != nil {
+			return wrapped
+		}
 		return fmt.Errorf("failed to list recent runs: %w", err)
 	}
 

--- a/internal/cli/server_utils.go
+++ b/internal/cli/server_utils.go
@@ -144,7 +144,8 @@ func StartServer(config *ServerConfig, pm *processManager) error {
 	// Start the engine from embedded binary if not already running
 	if !pm.IsComponentRunning(Engine) {
 		Logger.Debug("starting Rocketship engine")
-		env := []string{"TEMPORAL_HOST=localhost:7233"}
+		env := os.Environ()
+		env = append(env, "TEMPORAL_HOST=localhost:7233")
 		if logLevel := os.Getenv("ROCKETSHIP_LOG"); logLevel != "" {
 			env = append(env, "ROCKETSHIP_LOG="+logLevel)
 		}

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.19" // This should be updated with each release
+	DefaultVersion   = "v0.5.20" // This should be updated with each release
 )
 
 type binaryMetadata struct {

--- a/internal/orchestrator/auth.go
+++ b/internal/orchestrator/auth.go
@@ -1,0 +1,148 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rocketship-ai/rocketship/internal/api/generated"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	authorizationHeader = "authorization"
+	bearerPrefix        = "Bearer "
+)
+
+// authExemptMethods lists RPCs that should always be accessible without authentication.
+var authExemptMethods = map[string]struct{}{
+	"/rocketship.v1.Engine/Health":        {},
+	"/rocketship.v1.Engine/GetServerInfo": {},
+}
+
+// NewAuthUnaryInterceptor returns a unary interceptor that enforces token authentication
+// on all RPCs except those listed in authExemptMethods.
+
+func (e *Engine) NewAuthUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := e.authorize(ctx, info.FullMethod); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func (e *Engine) NewAuthStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := e.authorize(stream.Context(), info.FullMethod); err != nil {
+			return err
+		}
+		return handler(srv, stream)
+	}
+}
+
+func (e *Engine) authorize(ctx context.Context, fullMethod string) error {
+	if e.authConfig.Disabled() {
+		return nil
+	}
+	if _, exempt := authExemptMethods[fullMethod]; exempt {
+		return nil
+	}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "missing metadata")
+	}
+
+	tokens := md.Get(authorizationHeader)
+	if len(tokens) == 0 {
+		return status.Error(codes.Unauthenticated, "missing authorization token")
+	}
+
+	header := strings.TrimSpace(tokens[0])
+	if header == "" {
+		return status.Error(codes.Unauthenticated, "empty authorization header")
+	}
+
+	if len(header) < len(bearerPrefix) || !strings.EqualFold(header[:len(bearerPrefix)], bearerPrefix) {
+		return status.Error(codes.Unauthenticated, "invalid authorization header")
+	}
+
+	token := strings.TrimSpace(header[len(bearerPrefix):])
+	if token == "" {
+		return status.Error(codes.Unauthenticated, "empty bearer token")
+	}
+
+	if !e.authConfig.Validate(token) {
+		return status.Error(codes.PermissionDenied, "invalid token")
+	}
+
+	return nil
+}
+
+// authConfig encapsulates token authentication state.
+type authConfig struct {
+	enabled bool
+	token   string
+}
+
+func (a authConfig) Disabled() bool { return !a.enabled }
+
+// Validate returns true if the provided token matches the configured secret.
+func (a authConfig) Validate(token string) bool {
+	return a.enabled && token == a.token
+}
+
+// configureServerInfo mutates the GetServerInfo response to reflect auth configuration.
+func (a authConfig) configureServerInfo(resp *generated.GetServerInfoResponse) {
+	if resp == nil {
+		return
+	}
+	resp.AuthEnabled = a.enabled
+	if !a.enabled {
+		if resp.AuthType == "" {
+			resp.AuthType = "none"
+		}
+		return
+	}
+	resp.AuthType = "token"
+	if !containsString(resp.Capabilities, "auth.token") {
+		resp.Capabilities = append(resp.Capabilities, "auth.token")
+	}
+}
+
+// ConfigureToken enables token authentication for the engine.
+func (e *Engine) ConfigureToken(token string) {
+	trimmed := strings.TrimSpace(token)
+	e.authConfig = authConfig{
+		enabled: trimmed != "",
+		token:   trimmed,
+	}
+}
+
+// MustConfigureToken reads configuration and panics if the supplied token is invalid.
+// Exported for tests and bootstrap wiring.
+func (e *Engine) MustConfigureToken(token string) {
+	trimmed := strings.TrimSpace(token)
+	if token != "" && trimmed == "" {
+		panic(fmt.Sprintf("invalid token (blank): %q", token))
+	}
+	e.ConfigureToken(trimmed)
+}
+
+// TokenAuthEnabled reports whether token authentication is currently enabled.
+func (e *Engine) TokenAuthEnabled() bool {
+	return !e.authConfig.Disabled()
+}
+
+func containsString(values []string, needle string) bool {
+	for _, v := range values {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/auth_test.go
+++ b/internal/orchestrator/auth_test.go
@@ -1,0 +1,180 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rocketship-ai/rocketship/internal/api/generated"
+	"go.temporal.io/sdk/client"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type noopTemporalClient struct{ client.Client }
+
+type testServerStream struct {
+	ctx context.Context
+}
+
+func (s *testServerStream) SetHeader(metadata.MD) error  { return nil }
+func (s *testServerStream) SendHeader(metadata.MD) error { return nil }
+func (s *testServerStream) SetTrailer(metadata.MD)       {}
+func (s *testServerStream) Context() context.Context     { return s.ctx }
+func (s *testServerStream) SendMsg(interface{}) error    { return nil }
+func (s *testServerStream) RecvMsg(interface{}) error    { return nil }
+
+func TestAuthInterceptor_AllowsRequestsWhenDisabled(t *testing.T) {
+	engine := NewEngine(&noopTemporalClient{})
+	interceptor := engine.NewAuthUnaryInterceptor()
+
+	called := false
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		called = true
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{FullMethod: "/rocketship.v1.Engine/CreateRun"}
+	if _, err := interceptor(context.Background(), nil, info, handler); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !called {
+		t.Fatal("handler was not invoked")
+	}
+}
+
+func TestAuthInterceptor_EnforcesToken(t *testing.T) {
+	engine := NewEngine(&noopTemporalClient{})
+	engine.ConfigureToken("secret-token")
+
+	interceptor := engine.NewAuthUnaryInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/rocketship.v1.Engine/CreateRun"}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	t.Run("missing metadata", func(t *testing.T) {
+		_, err := interceptor(context.Background(), nil, info, handler)
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected unauthenticated, got %v", err)
+		}
+	})
+
+	t.Run("invalid header", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Token abc"))
+		_, err := interceptor(ctx, nil, info, handler)
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected unauthenticated for bad prefix, got %v", err)
+		}
+	})
+
+	t.Run("wrong token", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer other"))
+		_, err := interceptor(ctx, nil, info, handler)
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("expected permission denied, got %v", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer secret-token"))
+		resp, err := interceptor(ctx, nil, info, handler)
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if resp != "ok" {
+			t.Fatalf("unexpected response %v", resp)
+		}
+	})
+}
+
+func TestAuthInterceptor_ExemptMethods(t *testing.T) {
+	engine := NewEngine(&noopTemporalClient{})
+	engine.ConfigureToken("secret-token")
+	interceptor := engine.NewAuthUnaryInterceptor()
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs())
+	info := &grpc.UnaryServerInfo{FullMethod: "/rocketship.v1.Engine/Health"}
+	if _, err := interceptor(ctx, nil, info, handler); err != nil {
+		t.Fatalf("expected exempt method to succeed, got %v", err)
+	}
+}
+
+func TestAuthStreamInterceptor(t *testing.T) {
+	engine := NewEngine(&noopTemporalClient{})
+	engine.ConfigureToken("secret-token")
+	interceptor := engine.NewAuthStreamInterceptor()
+
+	info := &grpc.StreamServerInfo{FullMethod: "/rocketship.v1.Engine/StreamLogs"}
+	handlerCalled := false
+	handler := func(_ interface{}, _ grpc.ServerStream) error {
+		handlerCalled = true
+		return nil
+	}
+
+	t.Run("missing token", func(t *testing.T) {
+		handlerCalled = false
+		err := interceptor(nil, &testServerStream{ctx: context.Background()}, info, handler)
+		if status.Code(err) != codes.Unauthenticated {
+			t.Fatalf("expected unauthenticated, got %v", err)
+		}
+		if handlerCalled {
+			t.Fatal("handler should not be called when auth fails")
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		handlerCalled = false
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer secret-token"))
+		if err := interceptor(nil, &testServerStream{ctx: ctx}, info, handler); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if !handlerCalled {
+			t.Fatal("handler was not invoked")
+		}
+	})
+}
+
+func TestConfigureServerInfo(t *testing.T) {
+	engine := NewEngine(&noopTemporalClient{})
+	resp, err := engine.GetServerInfo(context.Background(), &generated.GetServerInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetServerInfo returned error: %v", err)
+	}
+	if resp.AuthEnabled {
+		t.Fatalf("expected auth disabled by default")
+	}
+	if resp.AuthType != "none" {
+		t.Fatalf("expected auth type none, got %s", resp.AuthType)
+	}
+
+	engine.ConfigureToken("secret-token")
+	resp, err = engine.GetServerInfo(context.Background(), &generated.GetServerInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetServerInfo returned error: %v", err)
+	}
+	if !resp.AuthEnabled {
+		t.Fatalf("expected auth enabled after token configure")
+	}
+	if resp.AuthType != "token" {
+		t.Fatalf("expected auth type token, got %s", resp.AuthType)
+	}
+	if !containsString(resp.Capabilities, "auth.token") {
+		t.Fatalf("expected auth.token capability present, capabilities: %v", resp.Capabilities)
+	}
+}
+
+func TestMustConfigureTokenPanicsOnWhitespace(t *testing.T) {
+	engine := NewEngine(&noopTemporalClient{})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for whitespace token")
+		}
+	}()
+	engine.MustConfigureToken("\n\t ")
+}

--- a/internal/orchestrator/engine.go
+++ b/internal/orchestrator/engine.go
@@ -5,7 +5,8 @@ import "go.temporal.io/sdk/client"
 // NewEngine creates a new Engine instance backed by the provided Temporal client.
 func NewEngine(c client.Client) *Engine {
 	return &Engine{
-		temporal: c,
-		runs:     make(map[string]*RunInfo),
+		temporal:   c,
+		runs:       make(map[string]*RunInfo),
+		authConfig: authConfig{},
 	}
 }

--- a/internal/orchestrator/engine_service.go
+++ b/internal/orchestrator/engine_service.go
@@ -211,13 +211,16 @@ func (e *Engine) GetServerInfo(ctx context.Context, _ *generated.GetServerInfoRe
 		version = "dev"
 	}
 
-	return &generated.GetServerInfoResponse{
+	resp := &generated.GetServerInfoResponse{
 		Version:      version,
 		AuthEnabled:  false,
 		AuthType:     "none",
 		AuthEndpoint: "",
 		Capabilities: []string{"discovery.v2"},
-	}, nil
+	}
+
+	e.authConfig.configureServerInfo(resp)
+	return resp, nil
 }
 
 func (e *Engine) ListRuns(ctx context.Context, req *generated.ListRunsRequest) (*generated.ListRunsResponse, error) {

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -10,9 +10,10 @@ import (
 
 type Engine struct {
 	generated.UnimplementedEngineServer
-	temporal client.Client
-	runs     map[string]*RunInfo
-	mu       sync.RWMutex
+	temporal   client.Client
+	runs       map[string]*RunInfo
+	mu         sync.RWMutex
+	authConfig authConfig
 }
 type RunInfo struct {
 	ID        string


### PR DESCRIPTION
This pull request introduces token-based authentication for Rocketship's gRPC engine and CLI, ensuring that only authorized users or CI jobs can invoke engine workflows. The changes include support for injecting and validating tokens via environment variables or files, updating the CLI to attach bearer tokens to requests, and surfacing clear error messages when authentication fails. Documentation and automated tests have also been added to guide users and verify enforcement.

**Token Authentication for gRPC Engine:**

* The engine now loads a token from `ROCKETSHIP_ENGINE_TOKEN` or `ROCKETSHIP_ENGINE_TOKEN_FILE` at startup and enforces token authentication for all gRPC requests. Interceptors are added to check bearer tokens, and server startup fails if the token is invalid or missing. (`cmd/engine/main.go`, `cmd/engine/main_test.go`) [[1]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R47-R56) [[2]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R101-R117) [[3]](diffhunk://#diff-eb635b234d9c5d4fd781151a34ef5b78acdd32b6bf418966fd0380a056674fe5R1-R46)

**CLI Integration and Error Handling:**

* The CLI attaches a bearer token from the `ROCKETSHIP_TOKEN` environment variable to all gRPC requests. If authentication fails, the CLI returns clear, actionable error messages instructing the user to supply a token. (`internal/cli/client.go`, `internal/cli/client_test.go`) [[1]](diffhunk://#diff-ff7fc3cd9bd8d8038c70920d77214aa8a194972e4b56916847602d8ae1a6fe55L33-R50) [[2]](diffhunk://#diff-ff7fc3cd9bd8d8038c70920d77214aa8a194972e4b56916847602d8ae1a6fe55R243-R280) [[3]](diffhunk://#diff-35a544e24c4b81d73d7e082d4980522fdbb018c69da6078490a6c69289b9d231R378-R432)

**Automated Testing and Validation:**

* New tests verify token loading from environment and file, ensure that empty token files produce errors, and confirm that the CLI attaches the correct authorization header and translates authentication errors into helpful messages. (`cmd/engine/main_test.go`, `internal/cli/client_test.go`) [[1]](diffhunk://#diff-eb635b234d9c5d4fd781151a34ef5b78acdd32b6bf418966fd0380a056674fe5R1-R46) [[2]](diffhunk://#diff-35a544e24c4b81d73d7e082d4980522fdbb018c69da6078490a6c69289b9d231R378-R432)

**Documentation Updates:**

* Deployment documentation now recommends enabling token authentication for gRPC, explains how to inject tokens via Kubernetes secrets and Helm values, and describes how to configure the CLI for authenticated access. (`docs/src/deploy/digitalocean.md`, `docs/src/deploy-on-your-cloud.md`) [[1]](diffhunk://#diff-3bb6a8063cc238ff0fa7a8eb662336b183fc8fd668bb8d0018d2d4abb6ffb5aeL177-R223) [[2]](diffhunk://#diff-cf1cfcec6f9a94057796749e84e5727e213090778640a3c29e3c8cc4e3475f43R30)

**End-to-End Test Script Enhancements:**

* The profile system test script now validates that token enforcement is active, checks that unauthenticated requests fail with helpful errors, and confirms that authenticated requests succeed. (`.github/scripts/test-profile-system.sh`)