### PR TITLE
OIDC Device Flow Login (CLI)

### DIFF
--- a/.github/scripts/test-profile-system.sh
+++ b/.github/scripts/test-profile-system.sh
@@ -17,8 +17,8 @@ if ! grep -q "default" <<<"${DEFAULT_LIST_OUTPUT}"; then
   echo "❌ default profile missing after reset"
   exit 1
 fi
-if ! grep -q "app.rocketship.sh" <<<"${DEFAULT_LIST_OUTPUT}"; then
-  echo "❌ default profile should point to app.rocketship.sh"
+if ! grep -q "cli.rocketship.sh" <<<"${DEFAULT_LIST_OUTPUT}"; then
+  echo "❌ default profile should point to cli.rocketship.sh"
   exit 1
 fi
 log "✅ default profile detected"

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -1,266 +1,121 @@
-# Rocketship Kubernetes & Discovery — Master Plan (v1)
+# Rocketship Cloud Launch — Master Plan (Usage-Based GitHub SSO)
 
-This plan delivers a production‑ready, Kubernetes‑hostable Rocketship server that the CLI can connect to securely, without over‑complexity. It ships incrementally via small PRs, each with targeted validation. We avoid CLI Kubernetes wrappers in v1 (no `rocketship kube`) to keep surface area small; Helm and kubectl remain the primary deployment tools. Enterprise needs (e.g., GlobalBank) are supported through a Helm chart and TLS/auth upgrades. RBAC is intentionally deferred to a later epic.
+## Goal
+
+Deliver a production-ready, usage-based Rocketship Cloud offering where customers authenticate via GitHub device flow, run tests against our hosted engine/worker, and manage teams/roles without relying on third-party SaaS IdPs such as Auth0. Enterprise and self-hosted customers must continue to work with the same RBAC scheme.
 
 ## Guiding Principles
 
-- Minimal v1 surface: profiles, TLS, discovery, Helm chart, health checks.
-- Keep CLI simple: no `rocketship kube` in v1; rely on Helm/kubectl.
-- Backward compatible: local `--auto` and existing flags continue to work.
-- Progressive auth: token first (great for CI/CD and self‑hosted), then OIDC device flow for CLI (RFC 8628); RBAC later.
-- Respect configuration precedence: explicit flags > env vars (e.g., `ROCKETSHIP_TOKEN`) > active profile > defaults.
-- Testable increments: add CI scripts/workflows as each feature lands.
+- **Single auth story:** Device flow for CLI, OAuth for the UI; Rocketship-issued JWTs with consistent claims regardless of underlying IdP.
+- **Broker-first:** A lightweight GitHub auth broker mints Rocketship JWTs so the engine continues to use our existing verifier and RBAC logic.
+- **Chart-driven:** Helm remains the tactical integration point. Usage-based cloud sets `auth.oidc.mode=github` (broker), while enterprise can point to any OIDC issuer.
+- **RBAC everywhere:** Claims-based roles (owner/admin/editor/viewer/service_account) enforced uniformly across cloud, enterprise, and self-hosted deployments.
 
 ## Outcome Overview
 
-- Users deploy Engine + Worker on Kubernetes via Helm.
-- Ingress controllers (NGINX, cloud load balancers) supported; HTTP health endpoint exposed; gRPC over TLS supported.
-- CLI can connect to `grpcs://` endpoints via profiles or `--engine`.
-- Server discovery tells the CLI which auth mode is active; CLI adapts.
-- Optional ingress with OIDC (via oauth2-proxy) for web endpoints; CLI remains token/JWT‑based.
-
-
-## Test Resources (For Manual/E2E Verification)
-
-These resources are available for manual validation where applicable:
-
-- Domain/TLS: `globalbank.rocketship.sh` with a ZeroSSL certificate
-  - Use to verify Ingress TLS and gRPC over TLS.
-  - Create a Kubernetes TLS secret (e.g., `globalbank-rocketship-tls`) with the ZeroSSL cert and key.
-  - Point DNS for `globalbank.rocketship.sh` (or subdomain) to the ingress/ALB.
-
-- IdP: Auth0 tenant/account
-  - Use to validate OIDC in two places when we reach them:
-    1) OIDC at ingress for web endpoints (PR 4, optional)
-    2) OIDC Device Flow for CLI login (PR 7, optional/phase‑next)
-
+- Shared DigitalOcean cluster hosts Rocketship Cloud:
+  - CLI endpoint: `cli.rocketship.sh`
+  - UI (oauth2-proxy + web): `app.rocketship.sh`
+  - GitHub SSO powers device flow via Rocketship broker.
+- CLI experiences (`rocketship login/status/logout`) work out-of-the-box with GitHub accounts.
+- Engine validates Rocketship JWTs for gRPC requests, enforcing basic RBAC.
+- Documentation covers both usage-based and enterprise setups, including Auth0/Okta/BYO instructions.
 
 ---
 
-## PR 1 — TLS‑Aware Engine Dialing + Profiles Polishing
+## PR 1 — GitHub Auth Broker
 
-What it accomplishes
-- Enables `rocketship` to connect to remote engines over TLS using `--engine https://host[:port]` or via profiles with TLS metadata.
-- Preserves localhost behavior; `--auto` remains unchanged.
+**What it accomplishes**
+- Implements an HTTP service that proxies the OAuth 2.0 Device Authorization Grant to GitHub and returns Rocketship-signed JWTs + refresh tokens.
+- Exposes JWKS so engines can validate tokens locally.
 
-Changes
-- `internal/cli/client.go`: resolve URL schemes (`http/https/grpc/grpcs`) and set dial creds; SNI set from profile TLS domain.
-- Logging polish and clearer error messages during dial/discovery.
+**Changes**
+- Add `internal/broker/` service (Go) with endpoints: `/device/code`, `/token`, `/refresh`, `/.well-known/jwks.json`.
+- JWT signer backed by RSA/ECDSA key; refresh token store encrypted at rest (file for dev, KMS/Vault later).
+- Unit tests covering device exchange and refresh paths using GitHub mocks.
 
-Tests (unit)
-- `go test ./...` additions:
-  - Address resolution and TLS options (table‑driven).
-  - Profile resolution precedence (explicit flag > profile > default).
+**CI integration**
+- New workflow running broker unit tests (`go test ./internal/broker`).
 
-CI integration
-- Workflow: `.github/workflows/go-tests.yml` (runs unit tests on PR).
-
----
-
-## PR 2 — Engine HTTP Health Endpoint
-
-What it accomplishes
-- Adds `/healthz` on engine HTTP port (7701) for ALB/NLB health checks and ops diagnostics.
-
-Changes
-- Small HTTP server in `cmd/engine` with `/` and `/healthz` returning 200 and minimal JSON.
-
-Tests (unit)
-- Handler returns 200 and valid payload.
-
-CI integration
-- Extend `go-tests.yml` (no network), cover handler logic.
+**Manual tests**
+- Local: run broker + CLI against GitHub staging credentials, confirm `rocketship login` obtains Rocketship JWTs.
 
 ---
 
-## PR 3 — Helm Chart (Engine + Worker)
+## PR 2 — Broker Helm Integration
 
-What it accomplishes
-- Helm chart for deploying Rocketship in Kubernetes (Engine, Worker, Services, optional Ingress).
-- Supports minikube (NodePort) and production (Ingress) via separate values files.
+**What it accomplishes**
+- Deploys the broker alongside the engine in the Rocketship chart and wires engine env vars to broker endpoints when `auth.oidc.mode=github`.
 
-Changes
-- `helm/rocketship/` chart with:
-  - `Deployment` and `Service` for engine and worker
-  - Optional `Ingress` (annotations for gRPC, health path)
-  - `values-minikube.yaml`, `values-production.yaml`
+**Changes**
+- Chart templates: broker deployment/service, optional ingress, secrets for GitHub client ID/secret.
+- Engine values accept new keys: `auth.oidc.mode`, `auth.oidc.github.clients[*]`, etc.
+- Default `values-oidc-web.yaml` updated to target broker instead of Auth0 for the usage-based preset.
 
-Manual test prerequisites (optional)
-- If validating TLS with a real hostname, create a TLS secret `globalbank-rocketship-tls` from the ZeroSSL cert and set `ingress.tls.secretName=globalbank-rocketship-tls` in values.
-- Create a DNS record for `globalbank.rocketship.sh` (or a subdomain) pointing to the ingress/ALB/NLB.
+**Tests**
+- `helm_template_check.sh` renders chart with broker enabled and asserts env vars match the broker endpoints, JWKS URL, etc.
 
-Tests (templating)
-- Scripts:
-  - `.github/scripts/helm_lint.sh` — helm lint + schema checks
-  - `.github/scripts/helm_template_check.sh` — render with minikube/production values and assert on key fields (port name `grpc`, health path `/healthz`, selectors)
-
-CI integration
-- Workflow: `.github/workflows/helm-chart.yml` running the two scripts on PR.
+**Manual tests**
+- Deploy chart to DO cluster with broker enabled, confirm engine discovery advertises broker endpoints.
 
 ---
 
-## PR 4 — Ingress Presets (gRPC baseline + optional OIDC web)
+## PR 3 — RBAC Claim Enforcement
 
-What it accomplishes
-- Document the existing NGINX gRPC values as the production baseline (DigitalOcean-ready).
-- Provide an additional values file for enabling OIDC at the ingress for HTTP/web endpoints via oauth2-proxy (leaves gRPC untouched).
+**What it accomplishes**
+- Establishes a minimal role model (`owner/admin/editor/viewer/service_account`), adds claim parsing to the engine, and blocks unauthorized RPCs (e.g., viewers cannot create runs).
 
-Changes
-- `charts/rocketship/values-production.yaml`: clarify it targets NGINX gRPC ingress (already in place).
-- `charts/rocketship/values-oidc-web.yaml`: add oauth2-proxy deployment and NGINX annotations for OIDC (issuer, client ID/secret, scopes, cookie name).
+**Changes**
+- Engine interceptors read `roles` claim from JWT; add a simple `authz` helper.
+- Broker minting logic includes role claims (reads from a persistent store, fallback to `owner` on first login).
+- CLI surfaces a helpful error when a call is denied by RBAC.
 
-Tests (templating)
-- Update `helm_template_check.sh` to render `values-oidc-web.yaml` and assert OIDC annotations and oauth2-proxy env are present.
+**Tests**
+- Engine unit tests simulating tokens with/without roles verifying RPC access.
+- Broker tests ensuring JWT claims include roles.
 
-CI integration
-- Reuse the Helm template check workflow; add the new values file to the matrix.
-
-Manual test prerequisites (optional)
-- Use the `globalbank.rocketship.sh` certificate via `globalbank-rocketship-tls`.
-- Configure oauth2-proxy with Auth0 (or other IdP) credentials and verify browser login gates `/healthz` (gRPC remains token-based in later PRs).
+**Manual tests**
+- Usage-based cloud: create two users, assign different roles, confirm CLI behavior matches expectations.
 
 ---
 
-## PR 5 — Discovery v2 (Capabilities & Version) [Optional in v1]
+## PR 4 — Cloud Org & Role Persistence
 
-What it accomplishes
-- Extends the discovery RPC to return server version, capability flags, preferred endpoints; CLI displays info in `profile show`.
+**What it accomplishes**
+- Introduces a lightweight persistence layer (Postgres table or Redis) for users, organisations, memberships, invitations, and role assignments.
 
-Changes
-- `proto/engine.proto`: add `GetServerInfo` returning version, capability flags, and advertised `auth_type` values: `none`, `token`, `oidc`, `cloud`.
-- Server returns static values initially.
+**Changes**
+- Broker (or new `internal/cloud` service) handles user onboarding, role management, and invitation/activation flows.
+- API endpoints to list/update org members (usable by future UI/CLI commands).
 
-Tests (unit)
-- Proto gen compiles; client displays info when the RPC is available.
+**Tests**
+- Unit tests for storage layer (CRUD operations, invitation acceptance).
+- Broker integration tests verifying `rocketship login` seeds default org and rewrites token claims accordingly.
 
-CI integration
-- Covered by go tests workflow.
-
----
-
-## PR 6 — Token Auth v1 (Enterprise‑Friendly)
-
-What it accomplishes
-- Enables bearer token auth for gRPC: simple, CLI‑friendly, and ingress‑agnostic.
-
-Changes
-- Engine: gRPC unary interceptor validating tokens against a secret or pluggable verifier. Support token prefix conventions for clarity (e.g., `rst_self_...` for self‑hosted; `rst_cloud_...` reserved for cloud).
-- CLI: attach token from `ROCKETSHIP_TOKEN` to gRPC metadata. Keep v1 minimal by not persisting tokens; profile‑stored tokens can be a v2 enhancement.
-
-Tests (unit)
-- Interceptor accept/deny paths.
-- Client header injection from env var.
-
-CI integration
-- Extend `go-tests.yml` for auth tests.
+**Manual tests**
+- Create org, invite additional GitHub usernames, login as invitee, ensure token carries correct org/role.
 
 ---
 
-## PR 7 — OIDC Device Flow Login (CLI) [Phase‑Next]
+## PR 5 — Docs & Onboarding Experience
 
-What it accomplishes
-- CLI obtains and stores OIDC tokens using OAuth 2.0 Device Authorization Grant (RFC 8628), ideal for CLI/SSH/headless environments. Uses JWT as bearer for gRPC. Suitable for enterprise IdPs and future cloud.
+**What it accomplishes**
+- Updates documentation for the new hosted product, including sign-up flow, CLI login, RBAC basics, and enterprise overrides.
 
-Changes
-- `rocketship login|logout|status` commands; device code UX (copy/paste code + URL). Token storage via OS keyring (with file fallback). Automatic refresh for long‑lived sessions when refresh token provided.
-- Engine validates JWTs via JWKS (caching with periodic refresh); discovery advertises `auth_type: oidc` or `cloud`.
+**Changes**
+- Cloud quick start: register, `rocketship login`, run tests, view results.
+- Enterprise and self-hosted guides updated to describe using the broker vs BYO IdP (Okta/Auth0/Azure). Include `rbac.yaml`/Terraform seeding instructions for self-hosted.
 
-Tests (unit)
-- Token storage and state machine; mocked device flow; JWT validation with test keys; JWKS cache behavior.
-
-CI integration
-- Add a non‑network test suite; E2E guarded in a separate workflow if secrets are provided.
-
-Manual test prerequisites (optional)
-- Configure an Auth0 application that permits Device Authorization Flow.
-- Provide device authorization, token, and issuer endpoints to the engine/CLI configuration for testing.
+**Tests**
+- Documentation build (mkdocs) passes.
+- CLI help text references GitHub login.
 
 ---
 
-## PR 8 — Docs & Examples
+## Future Enhancements (Backlog)
 
-What it accomplishes
-- Documentation for Kubernetes deployment with Helm, minikube quick start, TLS/auth configuration, and profile usage.
+- Additional SSO providers via broker (Google, GitLab).
+- Web UI for org/role management and billing integration.
+- Audit log streaming and webhook events.
+- Fine-grained project-level permissions.
 
-Changes
-- Update `docs/src/deploy-on-kubernetes.md` to Helm‑first flow.
-- Add “Ingress with OIDC at ALB (Web)” and “gRPC over ALB/NLB” sections.
-
-Tests
-- Documentation build in CI.
-
-CI integration
-- Workflow: `.github/workflows/docs.yml` building docs on PR.
-
----
-
-## Why No `rocketship kube` in v1?
-
-- Reduces maintenance burden and user confusion (Helm/kubectl are standard and powerful).
-- Keeps CLI focused on test execution and server discovery/auth.
-- We can revisit a `kube` group later if we identify high‑value wrappers (e.g., `connect` that reads ingress/service to auto‑create a profile).
-
----
-
-## Integration Testing Details (Scripts & Workflows)
-
-Planned scripts under `.github/scripts/`:
-
-- `helm_lint.sh`
-  - Installs helm (if needed), runs `helm lint helm/rocketship`.
-
-- `helm_template_check.sh`
-  - Renders chart with: default, `values-minikube.yaml`, `values-production.yaml`, `values-grpc.yaml`, `values-oidc-web.yaml`.
-  - Uses `yq`/`jq`/`grep` assertions:
-    - Engine service has port name `grpc` and targetPort 7700
-    - Health path `/healthz` appears in ingress annotations when enabled
-    - Worker deployment has correct labels/selectors
-
-- `go_unit.sh`
-  - Runs `go test ./...` with race; caches modules.
-
-Workflows under `.github/workflows/`:
-
-- `go-tests.yml`
-  - Triggers on PR; runs `go_unit.sh`.
-
-- `helm-chart.yml`
-  - Triggers on PR; sets up helm; runs `helm_lint.sh` and `helm_template_check.sh` on a matrix of values files.
-
-- `docs.yml`
-  - Builds docs to ensure no broken references.
-
-Optional E2E (follow‑up)
-- A gated workflow using kind/minikube to install the chart and probe `/healthz`; disabled by default, enabled in a staging branch or with a label.
-- A gated auth workflow running a local mock OIDC provider (or static JWKS) to issue a JWT and verify engine authorization end‑to‑end.
-
----
-
-## Ingress With OIDC at ALB (For Web) vs gRPC For CLI
-
-Ingress pattern: ALB can enforce OIDC at the edge using annotations (issuer, authorize/token/userinfo endpoints, client secret), maintaining a browser session via `AWSELBAuthSessionCookie`. This works well for web UIs and HTTP routes. However, OIDC at ALB is not compatible with raw gRPC clients (the redirect/302-based flow breaks gRPC). Therefore:
-
-- Use OIDC at ALB for web/HTTP endpoints (future Rocketship web UI, simple status pages).
-- Keep the Engine gRPC ingress separate and protect gRPC via application-level auth (token or JWT validated by the engine). This is CLI-friendly and avoids ALB redirect complexity.
-
-The chart will ship two presets:
-- `values-grpc.yaml` — gRPC ingress with `alb.ingress.kubernetes.io/backend-protocol-version: GRPC`, service port named `grpc`.
-- `values-oidc-web.yaml` — OIDC annotations for web endpoints; session cookie and scopes configurable. Not used for gRPC.
-
-RBAC Note
-- RBAC is out of scope for this epic. Plan to add role/permission enforcement once orgs/users are fully modeled and JWTs are in place (v2).
-
----
-
-## Post-Epic Naming Alignment (Managed Cloud & Self-Hosted)
-
-When the v1 workstream (PRs 1–8) completes and we begin prepping the managed cloud rollout:
-
-- **Web UI hostnames**
-  - Self-hosted reference environments: migrate the web ingress to become the primary apex host (`globalbank.rocketship.sh`).
-  - Managed cloud environment: serve the UI from `app.rocketship.sh`.
-- **CLI / gRPC hostnames**
-  - Self-hosted reference environments: move the gRPC ingress to `cli.globalbank.rocketship.sh` (profiles and docs must be updated accordingly).
-  - Managed cloud environment: expose the gRPC endpoint at `cli.rocketship.sh`.
-
-This hostname swap is intentionally deferred until after PR 8 so the current validation work stays stable. Capture it as a dedicated follow-up task that updates Helm values, DNS guidance, documentation, and profile examples in one pass.

--- a/charts/rocketship/templates/engine-deployment.yaml
+++ b/charts/rocketship/templates/engine-deployment.yaml
@@ -43,6 +43,42 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
+            {{- if .Values.auth.oidc.enabled }}
+            - name: ROCKETSHIP_AUTH_MODE
+              value: "oidc"
+            {{- if .Values.auth.oidc.issuer }}
+            - name: ROCKETSHIP_OIDC_ISSUER
+              value: {{ .Values.auth.oidc.issuer | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.clientID }}
+            - name: ROCKETSHIP_OIDC_CLIENT_ID
+              value: {{ .Values.auth.oidc.clientID | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.audience }}
+            - name: ROCKETSHIP_OIDC_AUDIENCE
+              value: {{ .Values.auth.oidc.audience | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.tokenEndpoint }}
+            - name: ROCKETSHIP_OIDC_TOKEN_ENDPOINT
+              value: {{ .Values.auth.oidc.tokenEndpoint | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.deviceEndpoint }}
+            - name: ROCKETSHIP_OIDC_DEVICE_ENDPOINT
+              value: {{ .Values.auth.oidc.deviceEndpoint | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.jwksURL }}
+            - name: ROCKETSHIP_OIDC_JWKS_URL
+              value: {{ .Values.auth.oidc.jwksURL | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.scopes }}
+            - name: ROCKETSHIP_OIDC_SCOPES
+              value: {{ join " " .Values.auth.oidc.scopes | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.allowedAlgorithms }}
+            - name: ROCKETSHIP_OIDC_ALLOWED_ALGS
+              value: {{ join "," .Values.auth.oidc.allowedAlgorithms | quote }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.engine.service.grpcPort }}

--- a/charts/rocketship/values-oidc-web.yaml
+++ b/charts/rocketship/values-oidc-web.yaml
@@ -71,3 +71,19 @@ web:
         value: "false"
       - name: OAUTH2_PROXY_HTTPS_ADDRESS
         value: ":0"
+
+auth:
+  oidc:
+    enabled: true
+    issuer: https://dev-0ankenxegmh7xfjm.us.auth0.com/
+    clientID: rocketship-cli
+    tokenEndpoint: https://dev-0ankenxegmh7xfjm.us.auth0.com/oauth/token
+    deviceEndpoint: https://dev-0ankenxegmh7xfjm.us.auth0.com/oauth/device/code
+    jwksURL: https://dev-0ankenxegmh7xfjm.us.auth0.com/.well-known/jwks.json
+    scopes:
+      - openid
+      - profile
+      - email
+      - offline_access
+    allowedAlgorithms:
+      - RS256

--- a/charts/rocketship/values-production.yaml
+++ b/charts/rocketship/values-production.yaml
@@ -7,11 +7,11 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   hosts:
-    - host: globalbank.rocketship.sh
+    - host: cli.globalbank.rocketship.sh
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: globalbank-rocketship-tls
       hosts:
-        - globalbank.rocketship.sh
+        - cli.globalbank.rocketship.sh

--- a/charts/rocketship/values.yaml
+++ b/charts/rocketship/values.yaml
@@ -20,6 +20,18 @@ temporal:
   host: "temporal-frontend.rocketship:7233"
   namespace: "default"
 
+auth:
+  oidc:
+    enabled: false
+    issuer: ""
+    clientID: ""
+    audience: ""
+    tokenEndpoint: ""
+    deviceEndpoint: ""
+    jwksURL: ""
+    scopes: []
+    allowedAlgorithms: []
+
 engine:
   replicaCount: 1
   image:

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/rocketship-ai/rocketship/internal/api/generated"
 	"github.com/rocketship-ai/rocketship/internal/cli"
@@ -45,15 +47,11 @@ func main() {
 	logger.Debug("creating engine orchestrator")
 	engine := orchestrator.NewEngine(c)
 
-	token, err := loadEngineToken()
-	if err != nil {
-		logger.Error("failed to load token", "error", err)
+	if err := configureAuthentication(engine); err != nil {
+		logger.Error("failed to configure authentication", "error", err)
 		os.Exit(1)
 	}
-	engine.MustConfigureToken(token)
-	if engine.TokenAuthEnabled() {
-		logger.Info("token authentication enabled")
-	}
+	logger.Info("authentication configured", "mode", engine.AuthMode())
 	startHealthServer()
 	startGRPCServer(engine)
 }
@@ -113,6 +111,150 @@ func loadEngineToken() (string, error) {
 
 	token := strings.TrimSpace(os.Getenv("ROCKETSHIP_ENGINE_TOKEN"))
 	return token, nil
+}
+
+func configureAuthentication(engine *orchestrator.Engine) error {
+	token, err := loadEngineToken()
+	if err != nil {
+		return err
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv("ROCKETSHIP_AUTH_MODE")))
+	issuer := strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_ISSUER"))
+	if mode == "oidc" || issuer != "" {
+		settings, err := loadOIDCSettings(issuer)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := engine.ConfigureOIDC(ctx, settings); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	engine.ConfigureToken(token)
+	return nil
+}
+
+func loadOIDCSettings(explicitIssuer string) (orchestrator.OIDCSettings, error) {
+	issuer := strings.TrimSpace(explicitIssuer)
+	if issuer == "" {
+		issuer = strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_ISSUER"))
+	}
+	if issuer == "" {
+		return orchestrator.OIDCSettings{}, fmt.Errorf("ROCKETSHIP_OIDC_ISSUER is required for oidc auth")
+	}
+	clientID := strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_CLIENT_ID"))
+	if clientID == "" {
+		return orchestrator.OIDCSettings{}, fmt.Errorf("ROCKETSHIP_OIDC_CLIENT_ID is required for oidc auth")
+	}
+
+	settings := orchestrator.OIDCSettings{
+		Issuer:         issuer,
+		ClientID:       clientID,
+		Audience:       strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_AUDIENCE")),
+		DeviceEndpoint: strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_DEVICE_ENDPOINT")),
+		TokenEndpoint:  strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_TOKEN_ENDPOINT")),
+		JWKSURL:        strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_JWKS_URL")),
+		Scopes:         parseScopes(os.Getenv("ROCKETSHIP_OIDC_SCOPES")),
+	}
+
+	if algs := strings.TrimSpace(os.Getenv("ROCKETSHIP_OIDC_ALLOWED_ALGS")); algs != "" {
+		settings.AllowedAlgorithms = splitAndTrim(algs)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	settings.HTTPClient = client
+
+	if settings.JWKSURL == "" || settings.TokenEndpoint == "" || settings.DeviceEndpoint == "" || len(settings.Scopes) == 0 {
+		doc, err := fetchOIDCDiscovery(context.Background(), client, issuer)
+		if err != nil {
+			return orchestrator.OIDCSettings{}, err
+		}
+		if settings.JWKSURL == "" {
+			settings.JWKSURL = doc.JWKSURI
+		}
+		if settings.TokenEndpoint == "" {
+			settings.TokenEndpoint = doc.TokenEndpoint
+		}
+		if settings.DeviceEndpoint == "" {
+			settings.DeviceEndpoint = doc.DeviceEndpoint
+		}
+		if len(settings.Scopes) == 0 && len(doc.ScopesSupported) > 0 {
+			settings.Scopes = append([]string(nil), doc.ScopesSupported...)
+		}
+	}
+
+	if len(settings.Scopes) == 0 {
+		settings.Scopes = []string{"openid", "profile", "email", "offline_access"}
+	}
+
+	if settings.JWKSURL == "" {
+		return orchestrator.OIDCSettings{}, fmt.Errorf("jwks_uri missing from discovery")
+	}
+	if settings.TokenEndpoint == "" {
+		return orchestrator.OIDCSettings{}, fmt.Errorf("token_endpoint missing from discovery")
+	}
+	if settings.DeviceEndpoint == "" {
+		return orchestrator.OIDCSettings{}, fmt.Errorf("device_authorization_endpoint missing from discovery")
+	}
+
+	return settings, nil
+}
+
+type discoveryDocument struct {
+	JWKSURI         string   `json:"jwks_uri"`
+	TokenEndpoint   string   `json:"token_endpoint"`
+	DeviceEndpoint  string   `json:"device_authorization_endpoint"`
+	ScopesSupported []string `json:"scopes_supported"`
+}
+
+func fetchOIDCDiscovery(ctx context.Context, client *http.Client, issuer string) (*discoveryDocument, error) {
+	endpoint := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build discovery request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery request failed: %w", err)
+	}
+    defer func() {
+        if cerr := resp.Body.Close(); cerr != nil {
+            cli.Logger.Debug("failed to close discovery response", "error", cerr)
+        }
+    }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oidc discovery request failed: %s", resp.Status)
+	}
+	var doc discoveryDocument
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("failed to decode discovery document: %w", err)
+	}
+	return &doc, nil
+}
+
+func parseScopes(raw string) []string {
+	parts := splitAndTrim(raw)
+	return parts
+}
+
+func splitAndTrim(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ' ' || r == ',' || r == '\n' || r == '\t'
+	})
+	var out []string
+	for _, f := range fields {
+		if trimmed := strings.TrimSpace(f); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func startHealthServer() {

--- a/docs/src/deploy-on-your-cloud.md
+++ b/docs/src/deploy-on-your-cloud.md
@@ -28,6 +28,7 @@ Both Rocketship services require the Temporal frontend host and namespace; every
 
 - Use `rocketship profile create` and `rocketship profile use` to store the engine endpoint (`grpcs://…`) and default to TLS where appropriate.
 - Inject a secret token into the engine (`ROCKETSHIP_ENGINE_TOKEN`) and export the same value as `ROCKETSHIP_TOKEN` in the CLI/CI environment so gRPC calls are authenticated.
+- Alternatively, set `ROCKETSHIP_AUTH_MODE=oidc` with the issuer/client metadata so the engine validates JWTs. Team members then run `rocketship login` (device flow) or `rocketship status` to manage their own credentials.
 - Run suites with `rocketship run --engine`. When profiles are active, the CLI resolves the engine address automatically.
 - Expose Prometheus/Grafana, RBAC, and authentication once the core stack is stable (tracked for future epics).
 

--- a/docs/src/deploy/digitalocean.md
+++ b/docs/src/deploy/digitalocean.md
@@ -269,6 +269,17 @@ rocketship status            # confirm expiry and identity
 
 The CLI stores access tokens securely and will refresh them as needed when contacting the engine.
 
+### RBAC considerations
+
+Regardless of where Rocketship runs (cloud usage-based, dedicated enterprise, or self-hosted), the recommended RBAC model is the same:
+
+1. **Issue Rocketship JWTs that carry organisation/team roles.** The broker (or customer IdP) mints access tokens with claims such as `org`, `project`, and `role` (`admin`, `editor`, `viewer`, `service-account`).
+2. **Engine enforces on every RPC.** When the CLI calls `CreateRun`, `ListRuns`, etc., the engine reads the claims and rejects calls from users without the required role. Tokens are short-lived and verified via JWKS, so enforcement is consistent across cloud and self-hosted clusters.
+3. **Role management lives in Rocketship.** Maintain an RBAC table in Rocketship Cloud (or the broker) so you can invite users, sync GitHub teams if desired, or import roles from customer IdPs. The engine only consumes the resulting claims; it doesn’t need to know whether they originated from GitHub, Okta, or internal configuration.
+4. **Future enhancements** (optional): provide an `rbac.yaml` or Terraform provider so self-hosted clusters can seed organisations/roles declaratively, and add UI to sync GitHub org/team membership if customers opt in.
+
+This approach lets you offer the same RBAC semantics in every environment. Usage-based customers can rely on the GitHub-backed broker, while enterprise tenants with their own IdP simply mint tokens that include the same claim set.
+
 ## 11. Smoke Test the Endpoint
 
 The Rocketship health endpoint answers gRPC, so an HTTPS request returns `415` with `application/grpc`, which confirms end-to-end TLS:

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -54,6 +54,17 @@ The `-a` flag tells Rocketship to automatically start and stop the local server,
 
 Rocketship automatically tracks your test runs with context information, making it easy to organize and find results.
 
+### Authenticating Against Remote Engines
+
+If you're connecting to a remote Rocketship deployment that requires OIDC, sign in once with the device-flow helper:
+
+```bash
+rocketship login
+# follow the printed URL to approve the device
+```
+
+The CLI stores short-lived tokens securely and will refresh them automatically when they expire. Run `rocketship status` to confirm the current profile is authenticated or `rocketship logout` to clear credentials.
+
 ### Adding Context to Your Runs
 
 You can add context to your test runs for better organization:

--- a/docs/src/reference/rocketship.md
+++ b/docs/src/reference/rocketship.md
@@ -16,9 +16,12 @@ Rocketship is a CLI tool for running automated tests.
 ### SEE ALSO
 
 * [rocketship get](rocketship_get.md)	 - Get details of a specific test run
+* [rocketship login](rocketship_login.md)	 - Authenticate the CLI via OIDC device flow
 * [rocketship list](rocketship_list.md)	 - List test runs
+* [rocketship logout](rocketship_logout.md)	 - Remove stored authentication tokens
 * [rocketship profile](rocketship_profile.md)	 - Manage connection profiles
 * [rocketship run](rocketship_run.md)	 - Run rocketship tests
+* [rocketship status](rocketship_status.md)	 - Show authentication status for a profile
 * [rocketship start](rocketship_start.md)	 - Start rocketship the rocketship server
 * [rocketship stop](rocketship_stop.md)	 - Stop rocketship the rocketship server
 * [rocketship validate](rocketship_validate.md)	 - Validate Rocketship test files against the JSON schema

--- a/docs/src/reference/rocketship_login.md
+++ b/docs/src/reference/rocketship_login.md
@@ -1,0 +1,29 @@
+## rocketship login
+
+Authenticate the CLI via OIDC device flow
+
+### Synopsis
+
+Launches the OAuth 2.0 device authorization flow for the active profile. The command displays a verification URL and code that must be approved in a browser. On success, the CLI stores short-lived access tokens (and refresh tokens when available) in the system keyring or an encrypted file fallback.
+
+```
+rocketship login [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for login
+  -p, --profile string  Profile to authenticate (defaults to active profile)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [rocketship](rocketship.md)	 - Rocketship CLI
+

--- a/docs/src/reference/rocketship_logout.md
+++ b/docs/src/reference/rocketship_logout.md
@@ -1,0 +1,29 @@
+## rocketship logout
+
+Remove stored authentication tokens
+
+### Synopsis
+
+Deletes the cached access and refresh tokens for the selected profile. Subsequent commands will require a new `rocketship login` before they can reach OIDC-protected engines.
+
+```
+rocketship logout [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for logout
+  -p, --profile string  Profile to clear (defaults to active profile)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [rocketship](rocketship.md)	 - Rocketship CLI
+

--- a/docs/src/reference/rocketship_status.md
+++ b/docs/src/reference/rocketship_status.md
@@ -1,0 +1,29 @@
+## rocketship status
+
+Show authentication status for a profile
+
+### Synopsis
+
+Displays token expiry, stored scopes, and identity information for the selected profile. This is useful for confirming whether a device-flow login is still valid or when the CLI should renew credentials.
+
+```
+rocketship status [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for status
+  -p, --profile string  Profile to inspect (defaults to active profile)
+```
+
+### Options inherited from parent commands
+
+```
+      --debug   Enable debug logging
+```
+
+### SEE ALSO
+
+* [rocketship](rocketship.md)	 - Rocketship CLI
+

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
 	github.com/fatih/color v1.18.0
 	github.com/go-sql-driver/mysql v1.9.2
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/itchyny/gojq v0.12.17
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
@@ -18,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	github.com/zalando/go-keyring v0.2.3
 	go.temporal.io/sdk v1.34.0
 	google.golang.org/grpc v1.72.0
 	google.golang.org/protobuf v1.36.6
@@ -27,14 +29,17 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
+	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -17,6 +19,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/danieljoos/wincred v1.2.0 h1:ozqKHaLK0W/ii4KVbbvluM91W2H3Sh0BncbUNPS7jLE=
+github.com/danieljoos/wincred v1.2.0/go.mod h1:FzQLLMKBFdvu+osBrnFODiv32YGwCfx0SkRa/eYHgec=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -49,8 +53,12 @@ github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqw
 github.com/go-sql-driver/mysql v1.9.2 h1:4cNKDYQ1I84SXslGddlsrMhc8k4LeDVj6Ad6WRjiHuU=
 github.com/go-sql-driver/mysql v1.9.2/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
@@ -155,6 +163,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97yms=
+github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=

--- a/internal/api/generated/engine.pb.go
+++ b/internal/api/generated/engine.pb.go
@@ -1303,15 +1303,21 @@ func (x *ServerEndpoint) GetAddress() string {
 }
 
 type GetServerInfoResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
-	AuthEnabled   bool                   `protobuf:"varint,2,opt,name=auth_enabled,json=authEnabled,proto3" json:"auth_enabled,omitempty"`
-	AuthType      string                 `protobuf:"bytes,3,opt,name=auth_type,json=authType,proto3" json:"auth_type,omitempty"`             // "none", "cloud", "oidc", "token"
-	AuthEndpoint  string                 `protobuf:"bytes,4,opt,name=auth_endpoint,json=authEndpoint,proto3" json:"auth_endpoint,omitempty"` // OAuth/OIDC endpoint for authentication flows
-	Capabilities  []string               `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
-	Endpoints     []*ServerEndpoint      `protobuf:"bytes,6,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                       protoimpl.MessageState `protogen:"open.v1"`
+	Version                     string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	AuthEnabled                 bool                   `protobuf:"varint,2,opt,name=auth_enabled,json=authEnabled,proto3" json:"auth_enabled,omitempty"`
+	AuthType                    string                 `protobuf:"bytes,3,opt,name=auth_type,json=authType,proto3" json:"auth_type,omitempty"`             // "none", "cloud", "oidc", "token"
+	AuthEndpoint                string                 `protobuf:"bytes,4,opt,name=auth_endpoint,json=authEndpoint,proto3" json:"auth_endpoint,omitempty"` // OAuth/OIDC endpoint for authentication flows
+	Capabilities                []string               `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	Endpoints                   []*ServerEndpoint      `protobuf:"bytes,6,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
+	DeviceAuthorizationEndpoint string                 `protobuf:"bytes,7,opt,name=device_authorization_endpoint,json=deviceAuthorizationEndpoint,proto3" json:"device_authorization_endpoint,omitempty"`
+	TokenEndpoint               string                 `protobuf:"bytes,8,opt,name=token_endpoint,json=tokenEndpoint,proto3" json:"token_endpoint,omitempty"`
+	Issuer                      string                 `protobuf:"bytes,9,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	Audience                    string                 `protobuf:"bytes,10,opt,name=audience,proto3" json:"audience,omitempty"`
+	Scopes                      []string               `protobuf:"bytes,11,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	ClientId                    string                 `protobuf:"bytes,12,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *GetServerInfoResponse) Reset() {
@@ -1384,6 +1390,48 @@ func (x *GetServerInfoResponse) GetEndpoints() []*ServerEndpoint {
 		return x.Endpoints
 	}
 	return nil
+}
+
+func (x *GetServerInfoResponse) GetDeviceAuthorizationEndpoint() string {
+	if x != nil {
+		return x.DeviceAuthorizationEndpoint
+	}
+	return ""
+}
+
+func (x *GetServerInfoResponse) GetTokenEndpoint() string {
+	if x != nil {
+		return x.TokenEndpoint
+	}
+	return ""
+}
+
+func (x *GetServerInfoResponse) GetIssuer() string {
+	if x != nil {
+		return x.Issuer
+	}
+	return ""
+}
+
+func (x *GetServerInfoResponse) GetAudience() string {
+	if x != nil {
+		return x.Audience
+	}
+	return ""
+}
+
+func (x *GetServerInfoResponse) GetScopes() []string {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
+func (x *GetServerInfoResponse) GetClientId() string {
+	if x != nil {
+		return x.ClientId
+	}
+	return ""
 }
 
 var File_engine_proto protoreflect.FileDescriptor
@@ -1504,14 +1552,21 @@ const file_engine_proto_rawDesc = "" +
 	"\x14GetServerInfoRequest\">\n" +
 	"\x0eServerEndpoint\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x18\n" +
-	"\aaddress\x18\x02 \x01(\tR\aaddress\"\xf7\x01\n" +
+	"\aaddress\x18\x02 \x01(\tR\aaddress\"\xcb\x03\n" +
 	"\x15GetServerInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12!\n" +
 	"\fauth_enabled\x18\x02 \x01(\bR\vauthEnabled\x12\x1b\n" +
 	"\tauth_type\x18\x03 \x01(\tR\bauthType\x12#\n" +
 	"\rauth_endpoint\x18\x04 \x01(\tR\fauthEndpoint\x12\"\n" +
 	"\fcapabilities\x18\x05 \x03(\tR\fcapabilities\x12;\n" +
-	"\tendpoints\x18\x06 \x03(\v2\x1d.rocketship.v1.ServerEndpointR\tendpoints2\xef\x04\n" +
+	"\tendpoints\x18\x06 \x03(\v2\x1d.rocketship.v1.ServerEndpointR\tendpoints\x12B\n" +
+	"\x1ddevice_authorization_endpoint\x18\a \x01(\tR\x1bdeviceAuthorizationEndpoint\x12%\n" +
+	"\x0etoken_endpoint\x18\b \x01(\tR\rtokenEndpoint\x12\x16\n" +
+	"\x06issuer\x18\t \x01(\tR\x06issuer\x12\x1a\n" +
+	"\baudience\x18\n" +
+	" \x01(\tR\baudience\x12\x16\n" +
+	"\x06scopes\x18\v \x03(\tR\x06scopes\x12\x1b\n" +
+	"\tclient_id\x18\f \x01(\tR\bclientId2\xef\x04\n" +
 	"\x06Engine\x12N\n" +
 	"\tCreateRun\x12\x1f.rocketship.v1.CreateRunRequest\x1a .rocketship.v1.CreateRunResponse\x12G\n" +
 	"\n" +

--- a/internal/cli/auth/manager.go
+++ b/internal/cli/auth/manager.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultServiceName = "rocketship"
+	tokenExpirySlack   = 2 * time.Minute
+)
+
+// Manager coordinates storage and refresh lifecycle.
+type Manager struct {
+	keyring  Store
+	fallback Store
+}
+
+var errKeyringDisabled = errors.New("rocketship keyring disabled")
+
+// NewManager constructs a Manager that prefers the system keyring.
+func NewManager() (*Manager, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine home directory: %w", err)
+	}
+	fallback, err := NewFileStore(fmt.Sprintf("%s/.rocketship/tokens", home))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialise token store: %w", err)
+	}
+
+	var keyringStore Store = NewKeyringStore(defaultServiceName)
+	if disabled := strings.ToLower(os.Getenv("ROCKETSHIP_DISABLE_KEYRING")); disabled == "1" || disabled == "true" {
+		keyringStore = &disabledStore{}
+	}
+
+	mgr := &Manager{
+		keyring:  keyringStore,
+		fallback: fallback,
+	}
+	return mgr, nil
+}
+
+// Save persists token data, preferring the OS keyring.
+func (m *Manager) Save(profile string, data TokenData) error {
+	if err := data.Validate(); err != nil {
+		return err
+	}
+	if err := m.keyring.Save(profile, data); err == nil {
+		return nil
+	}
+	if err := m.fallback.Save(profile, data); err != nil {
+		return fmt.Errorf("failed to store tokens on disk: %w", err)
+	}
+	return nil
+}
+
+// Load returns stored tokens for a profile.
+func (m *Manager) Load(profile string) (TokenData, error) {
+	data, err := m.keyring.Load(profile)
+	if err == nil {
+		return data, nil
+	}
+	ls, loadErr := m.fallback.Load(profile)
+	if loadErr != nil {
+		if errors.Is(loadErr, ErrTokenNotFound) {
+			return TokenData{}, ErrTokenNotFound
+		}
+		return TokenData{}, loadErr
+	}
+	return ls, nil
+}
+
+// Delete removes tokens for a profile.
+func (m *Manager) Delete(profile string) error {
+	_ = m.keyring.Delete(profile)
+	if err := m.fallback.Delete(profile); err != nil && !errors.Is(err, ErrTokenNotFound) {
+		return fmt.Errorf("failed to delete fallback token: %w", err)
+	}
+	return nil
+}
+
+// AccessToken returns the usable access token, refreshing when necessary.
+func (m *Manager) AccessToken(profile string, refreshFn func(TokenData) (TokenData, error)) (string, error) {
+	data, err := m.Load(profile)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) {
+			return "", err
+		}
+		return "", fmt.Errorf("failed to load tokens: %w", err)
+	}
+
+	if data.IsExpired(tokenExpirySlack) {
+		if !data.HasRefresh() {
+			return "", errors.New("access token expired and no refresh token available")
+		}
+		if refreshFn == nil {
+			return "", errors.New("refresh function not provided")
+		}
+		refreshed, err := refreshFn(data)
+		if err != nil {
+			return "", fmt.Errorf("failed to refresh token: %w", err)
+		}
+		if err := m.Save(profile, refreshed); err != nil {
+			return "", err
+		}
+		data = refreshed
+	}
+
+	return data.AccessToken, nil
+}
+
+type disabledStore struct{}
+
+func (d *disabledStore) Save(string, TokenData) error   { return errKeyringDisabled }
+func (d *disabledStore) Load(string) (TokenData, error) { return TokenData{}, errKeyringDisabled }
+func (d *disabledStore) Delete(string) error            { return errKeyringDisabled }

--- a/internal/cli/auth/manager_test.go
+++ b/internal/cli/auth/manager_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestManagerFallbackToFileStore(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("ROCKETSHIP_DISABLE_KEYRING", "1")
+
+	mgr, err := NewManager()
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	token := TokenData{
+		AccessToken:  "abc",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+		RefreshToken: "refresh",
+	}
+
+	// Force keyring failure by pointing service to empty path and removing permissions.
+	mgr.keyring = &failingStore{err: errors.New("keyring unsupported")}
+
+	if err := mgr.Save("test", token); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := mgr.Load("test")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.AccessToken != "abc" {
+		t.Fatalf("expected access token abc, got %s", loaded.AccessToken)
+	}
+
+	if err := mgr.Delete("test"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTokenDataMarshalRoundTrip(t *testing.T) {
+	t.Setenv("ROCKETSHIP_DISABLE_KEYRING", "1")
+	td := TokenData{
+		AccessToken:  "token",
+		RefreshToken: "refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Minute),
+		Scopes:       []string{"openid", "email"},
+	}
+
+	payload, err := td.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	round, err := UnmarshalTokenData(payload)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if round.AccessToken != td.AccessToken || len(round.Scopes) != len(td.Scopes) {
+		t.Fatalf("round trip mismatch")
+	}
+}
+
+// failingStore implements Store and always returns the provided error.
+type failingStore struct {
+	err error
+}
+
+func (f *failingStore) Save(string, TokenData) error   { return f.err }
+func (f *failingStore) Load(string) (TokenData, error) { return TokenData{}, f.err }
+func (f *failingStore) Delete(string) error            { return f.err }
+
+func TestFileStorePathSanitisation(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore failed: %v", err)
+	}
+	td := TokenData{AccessToken: "abc", TokenType: "Bearer"}
+	if err := store.Save("foo/bar", td); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "foo_bar.json")); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+}

--- a/internal/cli/auth/store.go
+++ b/internal/cli/auth/store.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zalando/go-keyring"
+)
+
+var (
+	ErrTokenNotFound = errors.New("token not found")
+)
+
+// Store persists per-profile token data.
+type Store interface {
+	Save(profile string, data TokenData) error
+	Load(profile string) (TokenData, error)
+	Delete(profile string) error
+}
+
+// KeyringStore stores tokens in the OS keyring.
+type KeyringStore struct {
+	service string
+}
+
+func NewKeyringStore(service string) *KeyringStore {
+	return &KeyringStore{service: service}
+}
+
+func (s *KeyringStore) key(profile string) string {
+	// Keep key deterministic yet human readable.
+	return fmt.Sprintf("profile:%s", profile)
+}
+
+func (s *KeyringStore) Save(profile string, data TokenData) error {
+	payload, err := data.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := keyring.Set(s.service, s.key(profile), string(payload)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *KeyringStore) Load(profile string) (TokenData, error) {
+	value, err := keyring.Get(s.service, s.key(profile))
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			return TokenData{}, ErrTokenNotFound
+		}
+		return TokenData{}, err
+	}
+	return UnmarshalTokenData([]byte(value))
+}
+
+func (s *KeyringStore) Delete(profile string) error {
+	if err := keyring.Delete(s.service, s.key(profile)); err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// FileStore stores tokens within ~/.rocketship/tokens/
+type FileStore struct {
+	dir string
+}
+
+func NewFileStore(dir string) (*FileStore, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+	return &FileStore{dir: dir}, nil
+}
+
+func (s *FileStore) path(profile string) string {
+	sanitized := strings.ReplaceAll(profile, string(os.PathSeparator), "_")
+	return filepath.Join(s.dir, sanitized+".json")
+}
+
+func (s *FileStore) Save(profile string, data TokenData) error {
+	payload, err := data.Marshal()
+	if err != nil {
+		return err
+	}
+	path := s.path(profile)
+	return os.WriteFile(path, payload, 0600)
+}
+
+func (s *FileStore) Load(profile string) (TokenData, error) {
+	path := s.path(profile)
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return TokenData{}, ErrTokenNotFound
+		}
+		return TokenData{}, err
+	}
+	return UnmarshalTokenData(payload)
+}
+
+func (s *FileStore) Delete(profile string) error {
+	path := s.path(profile)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/cli/auth/token_data.go
+++ b/internal/cli/auth/token_data.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// TokenData represents persisted OAuth tokens for a profile.
+type TokenData struct {
+	AccessToken    string    `json:"access_token"`
+	RefreshToken   string    `json:"refresh_token,omitempty"`
+	TokenType      string    `json:"token_type"`
+	Expiry         time.Time `json:"expiry"`
+	Scopes         []string  `json:"scopes,omitempty"`
+	IDToken        string    `json:"id_token,omitempty"`
+	Issuer         string    `json:"issuer,omitempty"`
+	ClientID       string    `json:"client_id,omitempty"`
+	Audience       string    `json:"audience,omitempty"`
+	TokenEndpoint  string    `json:"token_endpoint,omitempty"`
+	DeviceEndpoint string    `json:"device_endpoint,omitempty"`
+}
+
+// Marshal serialises the token payload.
+func (t TokenData) Marshal() ([]byte, error) {
+	return json.MarshalIndent(t, "", "  ")
+}
+
+// UnmarshalTokenData deserialises TokenData from JSON.
+func UnmarshalTokenData(data []byte) (TokenData, error) {
+	var td TokenData
+	if err := json.Unmarshal(data, &td); err != nil {
+		return TokenData{}, err
+	}
+	return td, nil
+}
+
+// IsExpired returns true if the access token has expired (with optional slack).
+func (t TokenData) IsExpired(slack time.Duration) bool {
+	if t.Expiry.IsZero() {
+		return false
+	}
+	return time.Now().Add(slack).After(t.Expiry)
+}
+
+// HasRefresh returns true when a refresh token is stored.
+func (t TokenData) HasRefresh() bool {
+	return t.RefreshToken != ""
+}
+
+// Validate performs a minimal sanity check before persisting tokens.
+func (t TokenData) Validate() error {
+	if t.AccessToken == "" {
+		return errors.New("access token is empty")
+	}
+	if t.TokenType == "" {
+		return errors.New("token type is empty")
+	}
+	return nil
+}

--- a/internal/cli/auth_cmd.go
+++ b/internal/cli/auth_cmd.go
@@ -1,0 +1,288 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/rocketship-ai/rocketship/internal/cli/auth"
+	"github.com/rocketship-ai/rocketship/internal/cli/oidc"
+	"github.com/spf13/cobra"
+)
+
+func NewLoginCmd() *cobra.Command {
+	var profileName string
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate the CLI via OIDC device flow",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogin(cmd.Context(), profileName)
+		},
+	}
+	cmd.Flags().StringVarP(&profileName, "profile", "p", "", "Profile to authenticate (defaults to active profile)")
+	return cmd
+}
+
+func NewLogoutCmd() *cobra.Command {
+	var profileName string
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Remove stored authentication tokens",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogout(profileName)
+		},
+	}
+	cmd.Flags().StringVarP(&profileName, "profile", "p", "", "Profile to clear (defaults to active profile)")
+	return cmd
+}
+
+func NewAuthStatusCmd() *cobra.Command {
+	var profileName string
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show authentication status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAuthStatus(profileName)
+		},
+	}
+	cmd.Flags().StringVarP(&profileName, "profile", "p", "", "Profile to inspect (defaults to active profile)")
+	return cmd
+}
+
+func runLogin(ctx context.Context, profileFlag string) error {
+	cfg, profile, name, err := resolveProfile(profileFlag)
+	if err != nil {
+		return err
+	}
+
+	client, err := newProfileClient(profile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := client.Close(); cerr != nil {
+			Logger.Debug("failed to close login client", "error", cerr)
+		}
+	}()
+
+	info, err := client.GetServerInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch server info: %w", err)
+	}
+	if !strings.EqualFold(info.AuthType, "oidc") {
+		return fmt.Errorf("profile %s is not configured for OIDC auth (reported type: %s)", name, info.AuthType)
+	}
+
+	flowCfg, err := buildFlowConfig(profile, info)
+	if err != nil {
+		return err
+	}
+
+	loginCtx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	device, err := oidc.StartDeviceAuthorization(loginCtx, flowCfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Follow the instructions below to approve access:")
+	if device.VerificationURIComplete != "" {
+		fmt.Printf("  1. Open %s\n", device.VerificationURIComplete)
+	} else {
+		fmt.Printf("  1. Open %s\n", device.VerificationURI)
+		fmt.Printf("  2. Enter code: %s\n", device.UserCode)
+	}
+	fmt.Printf("This code expires in %s.\n", device.ExpiresIn.Round(time.Second))
+	fmt.Println("Waiting for approval...")
+
+	tokenData, err := oidc.PollToken(loginCtx, flowCfg, device)
+	if err != nil {
+		return err
+	}
+
+	manager, err := auth.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := manager.Save(name, tokenData); err != nil {
+		return err
+	}
+
+	// Persist issuer/client metadata for the profile so status and future logins have context
+	profile.Auth.Issuer = flowCfg.Issuer
+	profile.Auth.ClientID = flowCfg.ClientID
+	cfg.AddProfile(profile)
+	if err := cfg.SaveConfig(); err != nil {
+		return fmt.Errorf("failed to persist profile metadata: %w", err)
+	}
+
+	if tokenData.IDToken != "" {
+		if user, err := decodeIDToken(tokenData.IDToken); err == nil {
+			fmt.Printf("Authenticated as %s\n", user)
+		}
+	}
+	fmt.Println("✅ Login complete")
+	return nil
+}
+
+func runLogout(profileFlag string) error {
+	_, _, name, err := resolveProfile(profileFlag)
+	if err != nil {
+		return err
+	}
+
+	manager, err := auth.NewManager()
+	if err != nil {
+		return err
+	}
+	if err := manager.Delete(name); err != nil {
+		return err
+	}
+	fmt.Printf("Logged out of profile %s\n", name)
+	return nil
+}
+
+func runAuthStatus(profileFlag string) error {
+	_, profile, name, err := resolveProfile(profileFlag)
+	if err != nil {
+		return err
+	}
+
+	manager, err := auth.NewManager()
+	if err != nil {
+		return err
+	}
+	tokenData, err := manager.Load(name)
+	if err != nil {
+		if errors.Is(err, auth.ErrTokenNotFound) {
+			fmt.Printf("Profile %s: not logged in\n", name)
+			return nil
+		}
+		return err
+	}
+
+	fmt.Printf("Profile: %s\n", name)
+	if profile.Auth.Issuer != "" {
+		fmt.Printf("Issuer: %s\n", profile.Auth.Issuer)
+	}
+	if tokenData.Audience != "" {
+		fmt.Printf("Audience: %s\n", tokenData.Audience)
+	}
+	if !tokenData.Expiry.IsZero() {
+		remaining := time.Until(tokenData.Expiry)
+		fmt.Printf("Access token expires in: %s\n", remaining.Round(time.Second))
+	} else {
+		fmt.Println("Access token expiry: not provided")
+	}
+	if tokenData.HasRefresh() {
+		fmt.Println("Refresh token: present")
+	} else {
+		fmt.Println("Refresh token: not stored")
+	}
+	if len(tokenData.Scopes) > 0 {
+		fmt.Printf("Scopes: %s\n", strings.Join(tokenData.Scopes, " "))
+	}
+	if tokenData.IDToken != "" {
+		if user, err := decodeIDToken(tokenData.IDToken); err == nil {
+			fmt.Printf("Identity: %s\n", user)
+		}
+	}
+
+	return nil
+}
+
+func resolveProfile(profileFlag string) (*Config, Profile, string, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, Profile{}, "", err
+	}
+
+	name := profileFlag
+	if name == "" {
+		name = cfg.DefaultProfile
+		if name == "" {
+			name = "default"
+		}
+	}
+
+	profile, exists := cfg.GetProfile(name)
+	if !exists {
+		return nil, Profile{}, "", fmt.Errorf("profile %s not found", name)
+	}
+	profile.Name = name
+	return cfg, profile, name, nil
+}
+
+func newProfileClient(profile Profile) (*EngineClient, error) {
+	scheme := "grpc"
+	if profile.TLS.Enabled {
+		scheme = "grpcs"
+	}
+	return NewEngineClient(fmt.Sprintf("%s://%s", scheme, profile.EngineAddress))
+}
+
+func buildFlowConfig(profile Profile, info *ServerInfo) (oidc.FlowConfig, error) {
+	cfg := oidc.FlowConfig{
+		ClientID:       info.ClientID,
+		Audience:       info.Audience,
+		Scopes:         info.Scopes,
+		DeviceEndpoint: info.DeviceEndpoint,
+		TokenEndpoint:  info.TokenEndpoint,
+		Issuer:         info.Issuer,
+	}
+	if cfg.ClientID == "" {
+		cfg.ClientID = profile.Auth.ClientID
+	}
+	if cfg.ClientID == "" {
+		return oidc.FlowConfig{}, errors.New("server did not advertise a client id")
+	}
+	if cfg.DeviceEndpoint == "" {
+		cfg.DeviceEndpoint = info.AuthEndpoint
+	}
+	if cfg.DeviceEndpoint == "" {
+		return oidc.FlowConfig{}, errors.New("device authorization endpoint missing from discovery")
+	}
+	if cfg.TokenEndpoint == "" {
+		return oidc.FlowConfig{}, errors.New("token endpoint missing from discovery")
+	}
+	if len(cfg.Scopes) == 0 {
+		cfg.Scopes = []string{"openid", "profile", "email", "offline_access"}
+	}
+	return cfg, nil
+}
+
+func decodeIDToken(idToken string) (string, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("invalid id token")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", err
+	}
+	var claims struct {
+		Email   string `json:"email"`
+		Subject string `json:"sub"`
+		Name    string `json:"name"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", err
+	}
+	switch {
+	case claims.Email != "":
+		return claims.Email, nil
+	case claims.Name != "":
+		return claims.Name, nil
+	case claims.Subject != "":
+		return claims.Subject, nil
+	default:
+		return "(unknown user)", nil
+	}
+}

--- a/internal/cli/auth_cmd_test.go
+++ b/internal/cli/auth_cmd_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import "testing"
+
+func TestBuildFlowConfigFallbacks(t *testing.T) {
+	profile := Profile{Name: "test", Auth: AuthProfile{ClientID: "client-123"}}
+	info := &ServerInfo{
+		AuthType:       "oidc",
+		DeviceEndpoint: "https://device",
+		TokenEndpoint:  "https://token",
+		Scopes:         []string{"openid"},
+	}
+	cfg, err := buildFlowConfig(profile, info)
+	if err != nil {
+		t.Fatalf("buildFlowConfig failed: %v", err)
+	}
+	if cfg.ClientID != "client-123" {
+		t.Fatalf("expected client id fallback, got %s", cfg.ClientID)
+	}
+	if len(cfg.Scopes) == 0 {
+		t.Fatalf("expected scopes to be populated")
+	}
+}
+
+func TestBuildFlowConfigMissingEndpoints(t *testing.T) {
+	_, err := buildFlowConfig(Profile{}, &ServerInfo{AuthType: "oidc"})
+	if err == nil {
+		t.Fatalf("expected error due to missing endpoints")
+	}
+}
+
+func TestDecodeIDToken(t *testing.T) {
+	token := "eyJhbGciOiJub25lIn0." +
+		"eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ." +
+		""
+	user, err := decodeIDToken(token)
+	if err != nil {
+		t.Fatalf("decodeIDToken failed: %v", err)
+	}
+	if user != "user@example.com" {
+		t.Fatalf("expected email, got %s", user)
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -47,11 +47,11 @@ type TeamContext struct {
 func GetDefaultProfile() Profile {
     return Profile{
         Name:          "default",
-        // Store host:port and rely on TLS config for transport semantics
-        EngineAddress: "app.rocketship.sh:443",
+        // Default cloud-hosted CLI endpoint
+        EngineAddress: "cli.rocketship.sh:443",
         TLS: TLSConfig{
             Enabled: true,
-            Domain:  "app.rocketship.sh",
+            Domain:  "cli.rocketship.sh",
         },
         Environment: make(map[string]string),
     }

--- a/internal/cli/oidc/device_flow.go
+++ b/internal/cli/oidc/device_flow.go
@@ -1,0 +1,243 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/rocketship-ai/rocketship/internal/cli/auth"
+)
+
+// FlowConfig captures the endpoints and identifiers required for device flow.
+type FlowConfig struct {
+	ClientID       string
+	Audience       string
+	Scopes         []string
+	DeviceEndpoint string
+	TokenEndpoint  string
+	Issuer         string
+}
+
+// DeviceCode represents the response from the device authorization endpoint.
+type DeviceCode struct {
+	DeviceCode              string
+	UserCode                string
+	VerificationURI         string
+	VerificationURIComplete string
+	ExpiresIn               time.Duration
+	Interval                time.Duration
+}
+
+// StartDeviceAuthorization initiates the device authorization grant.
+func StartDeviceAuthorization(ctx context.Context, cfg FlowConfig) (*DeviceCode, error) {
+	if cfg.DeviceEndpoint == "" {
+		return nil, fmt.Errorf("device authorization endpoint missing")
+	}
+	if cfg.ClientID == "" {
+		return nil, fmt.Errorf("client id missing")
+	}
+
+	form := url.Values{}
+	form.Set("client_id", cfg.ClientID)
+	if len(cfg.Scopes) > 0 {
+		form.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+	if cfg.Audience != "" {
+		form.Set("audience", cfg.Audience)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.DeviceEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		snippet := strings.TrimSpace(string(b))
+		if snippet == "" {
+			snippet = resp.Status
+		}
+		return nil, fmt.Errorf("device authorization failed: %s", snippet)
+	}
+
+	var dr deviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return nil, fmt.Errorf("failed to decode device authorization response: %w", err)
+	}
+
+	code := &DeviceCode{
+		DeviceCode:              dr.DeviceCode,
+		UserCode:                dr.UserCode,
+		VerificationURI:         dr.VerificationURI,
+		VerificationURIComplete: dr.VerificationURIComplete,
+		ExpiresIn:               time.Duration(dr.ExpiresIn) * time.Second,
+	}
+	interval := dr.Interval
+	if interval <= 0 {
+		interval = 5
+	}
+	code.Interval = time.Duration(interval) * time.Second
+
+	return code, nil
+}
+
+// PollToken polls the token endpoint until the user completes authentication.
+func PollToken(ctx context.Context, cfg FlowConfig, code *DeviceCode) (auth.TokenData, error) {
+	if cfg.TokenEndpoint == "" {
+		return auth.TokenData{}, fmt.Errorf("token endpoint missing")
+	}
+	if code == nil {
+		return auth.TokenData{}, fmt.Errorf("device code response missing")
+	}
+
+	deadline := time.Now().Add(code.ExpiresIn)
+	interval := code.Interval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	for {
+		if time.Now().After(deadline) {
+			return auth.TokenData{}, fmt.Errorf("device code expired before approval")
+		}
+
+		token, retry, err := exchangeDeviceCode(ctx, cfg, code.DeviceCode)
+		if err == nil {
+			token.DeviceEndpoint = cfg.DeviceEndpoint
+			token.TokenEndpoint = cfg.TokenEndpoint
+			token.ClientID = cfg.ClientID
+			token.Audience = cfg.Audience
+			token.Issuer = cfg.Issuer
+			if len(token.Scopes) == 0 {
+				token.Scopes = cfg.Scopes
+			}
+			return token, nil
+		}
+
+		switch retry {
+		case retryContinue:
+			select {
+			case <-time.After(interval):
+				continue
+			case <-ctx.Done():
+				return auth.TokenData{}, ctx.Err()
+			}
+		case retrySlowDown:
+			interval += 5 * time.Second
+			select {
+			case <-time.After(interval):
+				continue
+			case <-ctx.Done():
+				return auth.TokenData{}, ctx.Err()
+			}
+		default:
+			return auth.TokenData{}, err
+		}
+	}
+}
+
+const (
+	retryNone retryDirective = iota
+	retryContinue
+	retrySlowDown
+)
+
+type retryDirective int
+
+func exchangeDeviceCode(ctx context.Context, cfg FlowConfig, deviceCode string) (auth.TokenData, retryDirective, error) {
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	form.Set("device_code", deviceCode)
+	form.Set("client_id", cfg.ClientID)
+	if cfg.Audience != "" {
+		form.Set("audience", cfg.Audience)
+	}
+	if len(cfg.Scopes) > 0 {
+		form.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return auth.TokenData{}, retryNone, fmt.Errorf("failed to build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return auth.TokenData{}, retryContinue, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		var tr tokenResponse
+		if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+			return auth.TokenData{}, retryNone, fmt.Errorf("failed to decode token response: %w", err)
+		}
+		return tokenDataFromResponse(tr, cfg), retryNone, nil
+	}
+
+	var er tokenErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return auth.TokenData{}, retryNone, fmt.Errorf("unexpected token error: %s", resp.Status)
+	}
+
+	switch er.Error {
+	case "authorization_pending":
+		return auth.TokenData{}, retryContinue, fmt.Errorf("authorization pending")
+	case "slow_down":
+		return auth.TokenData{}, retrySlowDown, fmt.Errorf("slow down polling")
+	case "expired_token":
+		return auth.TokenData{}, retryNone, fmt.Errorf("device code expired")
+	case "access_denied":
+		return auth.TokenData{}, retryNone, fmt.Errorf("end user denied the request")
+	default:
+		return auth.TokenData{}, retryNone, fmt.Errorf("token exchange failed: %s", er.ErrorDescription)
+	}
+}
+
+func tokenDataFromResponse(tr tokenResponse, cfg FlowConfig) auth.TokenData {
+	expiry := time.Time{}
+	if tr.ExpiresIn > 0 {
+		expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	scopes := cfg.Scopes
+	if tr.Scope != "" {
+		scopes = strings.Fields(tr.Scope)
+	}
+	return auth.TokenData{
+		AccessToken:    tr.AccessToken,
+		RefreshToken:   tr.RefreshToken,
+		TokenType:      tr.TokenType,
+		Expiry:         expiry,
+		Scopes:         scopes,
+		IDToken:        tr.IDToken,
+		TokenEndpoint:  cfg.TokenEndpoint,
+		DeviceEndpoint: cfg.DeviceEndpoint,
+		ClientID:       cfg.ClientID,
+		Audience:       cfg.Audience,
+		Issuer:         cfg.Issuer,
+	}
+}
+
+type deviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
+	ExpiresIn               int64  `json:"expires_in"`
+	Interval                int64  `json:"interval,omitempty"`
+}

--- a/internal/cli/oidc/refresh.go
+++ b/internal/cli/oidc/refresh.go
@@ -1,0 +1,89 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/rocketship-ai/rocketship/internal/cli/auth"
+)
+
+const httpTimeout = 30 * time.Second
+
+// RefreshAccessToken exchanges a refresh token for new credentials.
+func RefreshAccessToken(ctx context.Context, current auth.TokenData) (auth.TokenData, error) {
+	if current.TokenEndpoint == "" {
+		return auth.TokenData{}, fmt.Errorf("token endpoint is not set")
+	}
+	if current.RefreshToken == "" {
+		return auth.TokenData{}, fmt.Errorf("refresh token missing")
+	}
+	if current.ClientID == "" {
+		return auth.TokenData{}, fmt.Errorf("client id missing for refresh")
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", current.RefreshToken)
+	form.Set("client_id", current.ClientID)
+	if current.Audience != "" {
+		form.Set("audience", current.Audience)
+	}
+	if len(current.Scopes) > 0 {
+		form.Set("scope", strings.Join(current.Scopes, " "))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, current.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return auth.TokenData{}, fmt.Errorf("failed to create refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return auth.TokenData{}, fmt.Errorf("refresh token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		snippet := strings.TrimSpace(string(b))
+		if snippet == "" {
+			snippet = resp.Status
+		}
+		return auth.TokenData{}, fmt.Errorf("refresh token request failed: %s", snippet)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return auth.TokenData{}, fmt.Errorf("failed to decode refresh response: %w", err)
+	}
+
+	updated := current
+	updated.AccessToken = tr.AccessToken
+	updated.TokenType = tr.TokenType
+	if tr.ExpiresIn > 0 {
+		updated.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	} else {
+		updated.Expiry = time.Time{}
+	}
+	if tr.RefreshToken != "" {
+		updated.RefreshToken = tr.RefreshToken
+	}
+	if tr.IDToken != "" {
+		updated.IDToken = tr.IDToken
+	}
+	if tr.Scope != "" {
+		updated.Scopes = strings.Fields(tr.Scope)
+	}
+
+	return updated, nil
+}
+
+// tokenResponse captures the subset of OAuth token response fields we care about.

--- a/internal/cli/oidc/types.go
+++ b/internal/cli/oidc/types.go
@@ -1,0 +1,15 @@
+package oidc
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	IDToken      string `json:"id_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+type tokenErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -340,6 +340,24 @@ func printServerDiscovery(profile Profile) {
 	if info.AuthEndpoint != "" {
 		fmt.Printf("  Auth Endpoint: %s\n", info.AuthEndpoint)
 	}
+	if info.DeviceEndpoint != "" {
+		fmt.Printf("  Device Endpoint: %s\n", info.DeviceEndpoint)
+	}
+	if info.TokenEndpoint != "" {
+		fmt.Printf("  Token Endpoint: %s\n", info.TokenEndpoint)
+	}
+	if info.Issuer != "" {
+		fmt.Printf("  Issuer: %s\n", info.Issuer)
+	}
+	if info.Audience != "" {
+		fmt.Printf("  Audience: %s\n", info.Audience)
+	}
+	if len(info.Scopes) > 0 {
+		fmt.Printf("  Scopes: %s\n", strings.Join(info.Scopes, " "))
+	}
+	if info.ClientID != "" {
+		fmt.Printf("  Client ID: %s\n", info.ClientID)
+	}
 
 	if len(info.Capabilities) > 0 {
 		caps := append([]string(nil), info.Capabilities...)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,9 @@ func NewRootCmd() *cobra.Command {
 		NewListCmd(),
 		NewGetCmd(),
 		NewProfileCmd(),
+		NewLoginCmd(),
+		NewLogoutCmd(),
+		NewAuthStatusCmd(),
 	)
 
 	return cmd

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.20" // This should be updated with each release
+	DefaultVersion   = "v0.5.21" // This should be updated with each release
 )
 
 type binaryMetadata struct {

--- a/internal/orchestrator/auth_oidc.go
+++ b/internal/orchestrator/auth_oidc.go
@@ -1,0 +1,306 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// OIDCSettings defines the configuration required to enable OIDC validation.
+type OIDCSettings struct {
+	Issuer            string
+	Audience          string
+	ClientID          string
+	JWKSURL           string
+	DeviceEndpoint    string
+	TokenEndpoint     string
+	Scopes            []string
+	HTTPClient        *http.Client
+	AllowedAlgorithms []string
+}
+
+type oidcProvider struct {
+	verifier       *oidcVerifier
+	Issuer         string
+	Audience       string
+	ClientID       string
+	Scopes         []string
+	DeviceEndpoint string
+	TokenEndpoint  string
+}
+
+func newOIDCProvider(ctx context.Context, settings OIDCSettings) (*oidcProvider, error) {
+	if settings.Issuer == "" {
+		return nil, errors.New("oidc issuer is required")
+	}
+	if settings.ClientID == "" {
+		return nil, errors.New("oidc client id is required")
+	}
+	if settings.JWKSURL == "" {
+		return nil, errors.New("jwks url is required")
+	}
+
+	verifier, err := newOIDCVerifier(ctx, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	provider := &oidcProvider{
+		verifier:       verifier,
+		Issuer:         settings.Issuer,
+		Audience:       settings.Audience,
+		ClientID:       settings.ClientID,
+		Scopes:         append([]string(nil), settings.Scopes...),
+		DeviceEndpoint: settings.DeviceEndpoint,
+		TokenEndpoint:  settings.TokenEndpoint,
+	}
+	return provider, nil
+}
+
+func (o *oidcProvider) Validate(ctx context.Context, bearer string) error {
+	if o.verifier == nil {
+		return status.Error(codes.Internal, "oidc verifier not initialised")
+	}
+	return o.verifier.Verify(ctx, bearer)
+}
+
+type oidcVerifier struct {
+	httpClient *http.Client
+	jwksURL    string
+	issuer     string
+	audience   string
+	algorithms map[string]struct{}
+	mu         sync.RWMutex
+	keys       map[string]interface{}
+	lastFetch  time.Time
+}
+
+func newOIDCVerifier(ctx context.Context, settings OIDCSettings) (*oidcVerifier, error) {
+	httpClient := settings.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	keys, err := fetchJWKS(ctx, httpClient, settings.JWKSURL)
+	if err != nil {
+		return nil, err
+	}
+
+	algs := map[string]struct{}{}
+	if len(settings.AllowedAlgorithms) == 0 {
+		settings.AllowedAlgorithms = []string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"}
+	}
+	for _, alg := range settings.AllowedAlgorithms {
+		algs[strings.ToUpper(strings.TrimSpace(alg))] = struct{}{}
+	}
+
+	return &oidcVerifier{
+		httpClient: httpClient,
+		jwksURL:    settings.JWKSURL,
+		issuer:     settings.Issuer,
+		audience:   settings.Audience,
+		algorithms: algs,
+		keys:       keys,
+		lastFetch:  time.Now(),
+	}, nil
+}
+
+func (o *oidcVerifier) Verify(ctx context.Context, token string) error {
+	parser := jwt.NewParser(jwt.WithValidMethods(o.allowedAlgorithms()))
+	claims := &jwt.RegisteredClaims{}
+	parsed, err := parser.ParseWithClaims(token, claims, func(t *jwt.Token) (interface{}, error) {
+		return o.keyFunc(ctx, t)
+	})
+	if err != nil {
+		return status.Error(codes.PermissionDenied, fmt.Sprintf("invalid token: %v", err))
+	}
+	if !parsed.Valid {
+		return status.Error(codes.PermissionDenied, "invalid token")
+	}
+
+	if err := claims.Valid(); err != nil {
+		return status.Error(codes.PermissionDenied, fmt.Sprintf("token validation failed: %v", err))
+	}
+
+	if o.issuer != "" && claims.Issuer != o.issuer {
+		return status.Error(codes.PermissionDenied, "issuer mismatch")
+	}
+	if o.audience != "" {
+		if !audienceContains(claims.Audience, o.audience) {
+			return status.Error(codes.PermissionDenied, "audience mismatch")
+		}
+	}
+	return nil
+}
+
+func (o *oidcVerifier) allowedAlgorithms() []string {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	algs := make([]string, 0, len(o.algorithms))
+	for alg := range o.algorithms {
+		algs = append(algs, alg)
+	}
+	return algs
+}
+
+func (o *oidcVerifier) keyFunc(ctx context.Context, token *jwt.Token) (interface{}, error) {
+	alg := ""
+	if token.Method != nil {
+		alg = strings.ToUpper(token.Method.Alg())
+	}
+	if _, ok := o.algorithms[alg]; !ok {
+		return nil, fmt.Errorf("algorithm %s not allowed", alg)
+	}
+
+	kid, _ := token.Header["kid"].(string)
+	key := o.lookupKey(kid)
+	if key != nil {
+		return key, nil
+	}
+
+	if err := o.refreshKeys(ctx); err != nil {
+		return nil, err
+	}
+	key = o.lookupKey(kid)
+	if key != nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("unable to resolve signing key")
+}
+
+func (o *oidcVerifier) lookupKey(kid string) interface{} {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	if kid != "" {
+		if key, ok := o.keys[kid]; ok {
+			return key
+		}
+	}
+	if kid == "" && len(o.keys) == 1 {
+		for _, key := range o.keys {
+			return key
+		}
+	}
+	return nil
+}
+
+func (o *oidcVerifier) refreshKeys(ctx context.Context) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	keys, err := fetchJWKS(ctx, o.httpClient, o.jwksURL)
+	if err != nil {
+		return err
+	}
+	o.keys = keys
+	o.lastFetch = time.Now()
+	return nil
+}
+
+type jwksDocument struct {
+	Keys []jwk `json:"keys"`
+}
+
+type jwk struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func fetchJWKS(ctx context.Context, client *http.Client, url string) (map[string]interface{}, error) {
+	if url == "" {
+		return nil, errors.New("jwks url is empty")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build JWKS request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("JWKS request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("JWKS request failed: %s", resp.Status)
+	}
+
+	var doc jwksDocument
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("failed to decode JWKS document: %w", err)
+	}
+	if len(doc.Keys) == 0 {
+		return nil, errors.New("jwks document contained no keys")
+	}
+
+	keys := make(map[string]interface{}, len(doc.Keys))
+	for _, k := range doc.Keys {
+		if strings.ToUpper(k.Kty) != "RSA" {
+			continue
+		}
+		pub, err := parseRSAJWK(k)
+		if err != nil {
+			continue
+		}
+		kid := k.Kid
+		if kid == "" {
+			kid = fmt.Sprintf("rsa_%d", len(keys)+1)
+		}
+		keys[kid] = pub
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("no usable RSA keys in JWKS document")
+	}
+	return keys, nil
+}
+
+func parseRSAJWK(j jwk) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(j.N)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode modulus: %w", err)
+	}
+	var eBytes []byte
+	if j.E != "" {
+		eBytes, err = base64.RawURLEncoding.DecodeString(j.E)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode exponent: %w", err)
+		}
+	}
+	if len(eBytes) == 0 {
+		eBytes = []byte{0x01, 0x00, 0x01} // 65537
+	}
+
+	modulus := new(big.Int).SetBytes(nBytes)
+	exponent := 0
+	for _, b := range eBytes {
+		exponent = exponent<<8 + int(b)
+	}
+	if exponent == 0 {
+		exponent = 65537
+	}
+
+	return &rsa.PublicKey{N: modulus, E: exponent}, nil
+}
+
+func audienceContains(list jwt.ClaimStrings, target string) bool {
+	for _, v := range list {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/auth_test.go
+++ b/internal/orchestrator/auth_test.go
@@ -2,8 +2,16 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/rocketship-ai/rocketship/internal/api/generated"
 	"go.temporal.io/sdk/client"
 	"google.golang.org/grpc"
@@ -169,12 +177,73 @@ func TestConfigureServerInfo(t *testing.T) {
 	}
 }
 
-func TestMustConfigureTokenPanicsOnWhitespace(t *testing.T) {
+func TestOIDCValidation(t *testing.T) {
 	engine := NewEngine(&noopTemporalClient{})
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for whitespace token")
-		}
-	}()
-	engine.MustConfigureToken("\n\t ")
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	jwksJSON := buildJWKS(key)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(jwksJSON))
+	}))
+	defer server.Close()
+
+	settings := OIDCSettings{
+		Issuer:         "https://example.com",
+		Audience:       "api",
+		ClientID:       "rocketship-cli",
+		JWKSURL:        server.URL,
+		TokenEndpoint:  "https://example.com/token",
+		DeviceEndpoint: "https://example.com/device",
+		Scopes:         []string{"openid"},
+	}
+
+	token := signJWT(key, settings.Issuer, settings.Audience)
+
+	ctx := context.Background()
+	if err := engine.ConfigureOIDC(ctx, settings); err != nil {
+		t.Fatalf("ConfigureOIDC failed: %v", err)
+	}
+
+	if err := engine.authConfig.Validate(ctx, token); err != nil {
+		t.Fatalf("expected token to validate, got %v", err)
+	}
+
+	// Wrong audience should fail
+	bad := signJWT(key, settings.Issuer, "wrong")
+	if err := engine.authConfig.Validate(ctx, bad); err == nil {
+		t.Fatal("expected audience mismatch to fail")
+	}
+}
+
+func buildJWKS(key *rsa.PrivateKey) string {
+	n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+	buf := make([]byte, 0)
+	e := key.E
+	for e > 0 {
+		buf = append([]byte{byte(e % 256)}, buf...)
+		e = e / 256
+	}
+	encodedE := base64.RawURLEncoding.EncodeToString(buf)
+	return fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":"test","use":"sig","alg":"RS256","n":"%s","e":"%s"}]}`, n, encodedE)
+}
+
+func signJWT(key *rsa.PrivateKey, issuer, audience string) string {
+	claims := jwt.RegisteredClaims{
+		Issuer:    issuer,
+		Subject:   "user",
+		Audience:  jwt.ClaimStrings{audience},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test"
+	signed, err := token.SignedString(key)
+	if err != nil {
+		panic(err)
+	}
+	return signed
 }

--- a/proto/engine.proto
+++ b/proto/engine.proto
@@ -146,4 +146,10 @@ message GetServerInfoResponse {
   string auth_endpoint = 4;    // OAuth/OIDC endpoint for authentication flows
   repeated string capabilities = 5;
   repeated ServerEndpoint endpoints = 6;
+  string device_authorization_endpoint = 7;
+  string token_endpoint = 8;
+  string issuer = 9;
+  string audience = 10;
+  repeated string scopes = 11;
+  string client_id = 12;
 }


### PR DESCRIPTION
This pull request introduces OIDC authentication support to the Rocketship engine and CLI, allowing users to authenticate with their own identities via device flow. It refactors authentication configuration in the engine, adds robust token storage and refresh logic to the CLI (with support for system keyrings and secure fallback), and updates documentation to guide users and administrators through OIDC setup and usage.

### Engine authentication and OIDC integration

* Refactored engine startup in `cmd/engine/main.go` to support both token and OIDC authentication modes, using a new `configureAuthentication` function that detects OIDC settings and configures the engine accordingly. OIDC settings are loaded from environment variables and, if necessary, via OpenID Connect discovery. [[1]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R4-R12) [[2]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41L48-R54) [[3]](diffhunk://#diff-376df540518ee144af59fceae8d999bb4653ccae2dfeee9ff5b445ed593d1c41R116-R259)

### CLI authentication and token management

* Added a new `internal/cli/auth/manager.go` implementing a `Manager` for storing, loading, and refreshing authentication tokens, preferring the system keyring but falling back to encrypted local storage. Includes logic for token expiry and refresh. Associated tests added in `internal/cli/auth/manager_test.go`. [[1]](diffhunk://#diff-540b08e0ebf14ffc6bd8a71703aaac2264230276d59cc2cb0be38de1af28b24eR1-R120) [[2]](diffhunk://#diff-5ee1735cb83f88ae4817a8aa3ebb77cb3bb1ea52018d1798f0ef134f2f9c3f96R1-R93)
* Updated dependencies in `go.mod` to support JWT handling, keyring access, and related features. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R13) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R22) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R32-R42)

### Documentation updates for OIDC

* Added instructions to `docs/src/deploy-on-your-cloud.md` and `docs/src/deploy/digitalocean.md` for enabling OIDC authentication, configuring engine environment variables, and guiding users through device flow login with the CLI. [[1]](diffhunk://#diff-cf1cfcec6f9a94057796749e84e5727e213090778640a3c29e3c8cc4e3475f43R31) [[2]](diffhunk://#diff-3bb6a8063cc238ff0fa7a8eb662336b183fc8fd668bb8d0018d2d4abb6ffb5aeL239-R267)
* Updated `docs/src/quickstart.md` with steps for authenticating against remote engines using OIDC device flow.

### CLI reference documentation

* Added new reference docs for `rocketship login`, `rocketship logout`, and `rocketship status` commands, describing their usage for OIDC authentication management. Updated main CLI reference to include these commands. [[1]](diffhunk://#diff-d1caf14d29ed3117cce60c06245a0e8c322ba9872a77716b2e17df63d787c147R1-R29) [[2]](diffhunk://#diff-56569cfade5cac1f9dc8797f2e59b2f93cbcdcab2a1e8f5798e0c9a81426a230R1-R29) [[3]](diffhunk://#diff-b2479a790bc3840165ecc89e9f6be569fdbbfb465ffec79855c6a81b20e0666eR1-R29) [[4]](diffhunk://#diff-41d50470e7bdb6de84192da954524608c1c4607f4b6b704f7573107434d9d47eR19-R24)