### PR TITLE
GitHub Auth Broker + Helm Integration

### DIFF
--- a/.docker/Dockerfile.authbroker
+++ b/.docker/Dockerfile.authbroker
@@ -1,0 +1,24 @@
+FROM golang:1.24-alpine AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o /bin/auth-broker ./cmd/authbroker
+
+FROM alpine:3.16
+
+WORKDIR /app
+
+COPY --from=builder /bin/auth-broker /bin/auth-broker
+
+EXPOSE 8080
+
+ENTRYPOINT ["/bin/auth-broker"]

--- a/.github/scripts/helm_template_check.sh
+++ b/.github/scripts/helm_template_check.sh
@@ -57,7 +57,7 @@ if ! grep -q "ROCKETSHIP_BROKER_SIGNING_KEY_FILE" <<<"$github_output"; then
   echo "Expected broker configuration env vars in GitHub preset" >&2
   exit 1
 fi
-if ! grep -q "auth.rocketship.sh" <<<"$github_output"; then
+if ! grep -q "auth.rocketship.globalbank.com" <<<"$github_output"; then
   echo "Expected auth broker ingress host in GitHub preset" >&2
   exit 1
 fi

--- a/.github/scripts/helm_template_check.sh
+++ b/.github/scripts/helm_template_check.sh
@@ -46,3 +46,14 @@ if ! grep -q "OAUTH2_PROXY_PROVIDER" <<<"$oidc_output"; then
   echo "Expected OIDC environment variables in oauth2-proxy deployment" >&2
   exit 1
 fi
+
+# GitHub broker preset should render broker deployment and env vars
+github_output=$(render -f "$CHART_DIR/values-github-cloud.yaml")
+if ! grep -q "rocketship-auth-broker" <<<"$github_output"; then
+  echo "Expected broker resources in values-github-cloud.yaml render" >&2
+  exit 1
+fi
+if ! grep -q "ROCKETSHIP_BROKER_SIGNING_KEY_FILE" <<<"$github_output"; then
+  echo "Expected broker configuration env vars in GitHub preset" >&2
+  exit 1
+fi

--- a/.github/scripts/helm_template_check.sh
+++ b/.github/scripts/helm_template_check.sh
@@ -57,3 +57,7 @@ if ! grep -q "ROCKETSHIP_BROKER_SIGNING_KEY_FILE" <<<"$github_output"; then
   echo "Expected broker configuration env vars in GitHub preset" >&2
   exit 1
 fi
+if ! grep -q "auth.rocketship.sh" <<<"$github_output"; then
+  echo "Expected auth broker ingress host in GitHub preset" >&2
+  exit 1
+fi

--- a/.github/scripts/helm_template_check.sh
+++ b/.github/scripts/helm_template_check.sh
@@ -48,9 +48,9 @@ if ! grep -q "OAUTH2_PROXY_PROVIDER" <<<"$oidc_output"; then
 fi
 
 # GitHub broker preset should render broker deployment and env vars
-github_output=$(render -f "$CHART_DIR/values-github-cloud.yaml")
+github_output=$(render -f "$CHART_DIR/values-github-globalbank.yaml")
 if ! grep -q "rocketship-auth-broker" <<<"$github_output"; then
-  echo "Expected broker resources in values-github-cloud.yaml render" >&2
+  echo "Expected broker resources in values-github-globalbank.yaml render" >&2
   exit 1
 fi
 if ! grep -q "ROCKETSHIP_BROKER_SIGNING_KEY_FILE" <<<"$github_output"; then

--- a/.github/scripts/test-profile-system.sh
+++ b/.github/scripts/test-profile-system.sh
@@ -23,24 +23,24 @@ if ! grep -q "cli.rocketship.sh" <<<"${DEFAULT_LIST_OUTPUT}"; then
 fi
 log "✅ default profile detected"
 
-log "Creating globalbank profile"
-rocketship profile create globalbank grpcs://globalbank.rocketship.sh >/dev/null
-rocketship profile use globalbank >/dev/null
+log "Creating cloud profile"
+rocketship profile create cloud grpcs://cli.rocketship.sh >/dev/null
+rocketship profile use cloud >/dev/null
 
 PROFILE_LIST=$(rocketship profile list)
-if ! grep -q "globalbank.*\\*" <<<"${PROFILE_LIST}"; then
-  echo "❌ globalbank profile not marked active"
+if ! grep -q "cloud.*\\*" <<<"${PROFILE_LIST}"; then
+  echo "❌ cloud profile not marked active"
   echo "${PROFILE_LIST}"
   exit 1
 fi
-if ! grep -q "enabled (globalbank.rocketship.sh)" <<<"${PROFILE_LIST}"; then
-  echo "❌ TLS expectation mismatch for globalbank"
+if ! grep -q "enabled (cli.rocketship.sh)" <<<"${PROFILE_LIST}"; then
+  echo "❌ TLS expectation mismatch for cloud"
   echo "${PROFILE_LIST}"
   exit 1
 fi
-log "✅ globalbank profile active with TLS"
+log "✅ cloud profile active with TLS"
 
-log "Running list against globalbank cluster (should require token)"
+log "Running list against cloud profile (should require token)"
 set +e
 LIST_OUTPUT=$(ROCKETSHIP_LOG=DEBUG rocketship list 2>&1)
 STATUS=$?
@@ -49,7 +49,7 @@ if [ ${STATUS} -eq 0 ]; then
   echo "❌ expected token enforcement to fail without ROCKETSHIP_TOKEN"
   exit 1
 fi
-if ! grep -q "requires a token" <<<"${LIST_OUTPUT}"; then
+if ! grep -q "engine requires a token" <<<"${LIST_OUTPUT}" || ! grep -q "ROCKETSHIP_TOKEN" <<<"${LIST_OUTPUT}"; then
   echo "❌ missing token guidance in failure output"
   echo "${LIST_OUTPUT}"
   exit 1
@@ -97,7 +97,7 @@ log "✅ discovery v2 surfaced via profile show"
 log "Stopping local engine"
 rocketship stop server >/dev/null 2>&1 || true
 
-rocketship profile use globalbank >/dev/null 2>&1 || true
+rocketship profile use cloud >/dev/null 2>&1 || true
 rocketship profile delete local >/dev/null 2>&1 || true
 
 log "Starting token-protected engine"
@@ -117,7 +117,7 @@ if [ ${STATUS} -eq 0 ]; then
   rocketship stop server >/dev/null 2>&1 || true
   exit 1
 fi
-if ! grep -q "requires a token" <<<"${TOKENLESS_OUTPUT}"; then
+if ! grep -q "engine requires a token" <<<"${TOKENLESS_OUTPUT}" || ! grep -q "ROCKETSHIP_TOKEN" <<<"${TOKENLESS_OUTPUT}"; then
   echo "❌ missing token guidance in failure output"
   echo "${TOKENLESS_OUTPUT}"
   rocketship stop server >/dev/null 2>&1 || true
@@ -145,7 +145,7 @@ log "✅ command succeeds when token supplied"
 log "Stopping token-protected engine"
 rocketship stop server >/dev/null 2>&1 || true
 
-rocketship profile use globalbank >/dev/null 2>&1 || true
+rocketship profile use cloud >/dev/null 2>&1 || true
 rocketship profile delete local-token >/dev/null 2>&1 || true
 
 log "Testing failure path with unreachable profile"
@@ -169,6 +169,6 @@ if ! grep -q "unreachable" <<<"${UNREACHABLE_OUTPUT}" && ! grep -q "127.0.0.1" <
 fi
 log "✅ unreachable profile produces explicit failure"
 
-log "Restoring globalbank profile for downstream tests"
-rocketship profile use globalbank >/dev/null
+log "Restoring cloud profile for downstream tests"
+rocketship profile use cloud >/dev/null
 log "✅ profile tests complete"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
           GOOS=linux GOARCH=arm64 go build -o bin/engine-linux-arm64 cmd/engine/main.go
           GOOS=windows GOARCH=amd64 go build -o bin/engine-windows-amd64.exe cmd/engine/main.go
 
+          # Build auth broker binaries
+          GOOS=darwin GOARCH=amd64 go build -o bin/auth-broker-darwin-amd64 cmd/authbroker/main.go
+          GOOS=darwin GOARCH=arm64 go build -o bin/auth-broker-darwin-arm64 cmd/authbroker/main.go
+          GOOS=linux GOARCH=amd64 go build -o bin/auth-broker-linux-amd64 cmd/authbroker/main.go
+          GOOS=linux GOARCH=arm64 go build -o bin/auth-broker-linux-arm64 cmd/authbroker/main.go
+          GOOS=windows GOARCH=amd64 go build -o bin/auth-broker-windows-amd64.exe cmd/authbroker/main.go
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -73,6 +80,11 @@ jobs:
             bin/engine-linux-amd64
             bin/engine-linux-arm64
             bin/engine-windows-amd64.exe
+            bin/auth-broker-darwin-amd64
+            bin/auth-broker-darwin-arm64
+            bin/auth-broker-linux-amd64
+            bin/auth-broker-linux-arm64
+            bin/auth-broker-windows-amd64.exe
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -146,6 +158,18 @@ jobs:
           tags: |
             rocketshipai/rocketship-worker:${{ steps.get_version.outputs.VERSION }}
             rocketshipai/rocketship-worker:latest
+
+      - name: Build and push Auth broker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .docker/Dockerfile.authbroker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            rocketshipai/rocketship-auth-broker:${{ steps.get_version.outputs.VERSION }}
+            rocketshipai/rocketship-auth-broker:latest
 
       - name: Trigger Go proxy to index new version
         run: |

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -14,8 +14,8 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 ## Outcome Overview
 
 - Shared DigitalOcean cluster hosts Rocketship Cloud:
-  - CLI endpoint: `cli.rocketship.sh`
-  - UI (oauth2-proxy + web): `app.rocketship.sh`
+  - CLI endpoint: `cli.rocketship.globalbank.com`
+  - UI (oauth2-proxy + web): `app.rocketship.globalbank.com`
   - GitHub SSO powers device flow via Rocketship broker.
 - CLI experiences (`rocketship login/status/logout`) work out-of-the-box with GitHub accounts.
 - Engine validates Rocketship JWTs for gRPC requests, enforcing basic RBAC.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -14,8 +14,8 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 ## Outcome Overview
 
 - Shared DigitalOcean cluster hosts Rocketship Cloud:
-  - CLI endpoint: `cli.rocketship.globalbank.com`
-  - UI (oauth2-proxy + web): `app.rocketship.globalbank.com`
+  - CLI endpoint: `cli.rocketship.sh`
+  - UI (oauth2-proxy + web): `app.rocketship.sh`
   - GitHub SSO powers device flow via Rocketship broker.
 - CLI experiences (`rocketship login/status/logout`) work out-of-the-box with GitHub accounts.
 - Engine validates Rocketship JWTs for gRPC requests, enforcing basic RBAC.
@@ -26,16 +26,19 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 ## PR 1 — GitHub Auth Broker + Helm Integration
 
 **What it accomplishes**
+
 - Implements an HTTP service that proxies the OAuth 2.0 Device Authorization Grant to GitHub and returns Rocketship-signed JWTs + refresh tokens.
 - Deploys the broker alongside the engine via Helm and wires engines to the broker endpoints when `auth.oidc.mode=github`.
 
 **Changes**
+
 - Add `internal/authbroker/` service and `cmd/authbroker` entrypoint (Go) with endpoints: `/device/code`, `/token`, `/refresh`, `/.well-known/jwks.json`.
 - JWT signer backed by RSA/ECDSA key; refresh token store encrypted at rest (file for dev, KMS/Vault later).
 - Helm templates for broker Deployment/Service/ConfigMap, and engine env var wiring when GitHub mode is enabled.
-- Usage preset `charts/rocketship/values-github-globalbank.yaml` (or update `values-oidc-web.yaml`) pointing to the broker.
+- Usage preset `charts/rocketship/values-github-web.yaml` (or update `values-oidc-web.yaml`) pointing to the broker.
 
 **Tests / validation**
+
 - Unit tests for broker endpoints with mocked GitHub responses.
 - `helm_template_check.sh` renders chart with `auth.oidc.mode=github` and asserts broker and engine env vars.
 - Manual validation: deploy broker + chart to DO cluster, run `rocketship login` + `rocketship run` end-to-end.
@@ -45,18 +48,22 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 ## PR 2 — RBAC Claim Enforcement
 
 **What it accomplishes**
+
 - Establishes a minimal role model (`owner/admin/editor/viewer/service_account`), adds claim parsing to the engine, and blocks unauthorized RPCs (e.g., viewers cannot create runs).
 
 **Changes**
+
 - Engine interceptors read `roles` claim from JWT; add a simple `authz` helper.
 - Broker minting logic includes role claims (reads from a persistent store, fallback to `owner` on first login).
 - CLI surfaces a helpful error when a call is denied by RBAC.
 
 **Tests**
+
 - Engine unit tests simulating tokens with/without roles verifying RPC access.
 - Broker tests ensuring JWT claims include roles.
 
 **Manual tests**
+
 - Usage-based cloud: create two users, assign different roles, confirm CLI behavior matches expectations.
 
 ---
@@ -64,17 +71,21 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 ## PR 3 — Cloud Org & Role Persistence
 
 What it accomplishes
+
 - Introduces a lightweight persistence layer (Postgres table or Redis) for users, organisations, memberships, invitations, and role assignments.
 
 Changes
+
 - Broker (or new `internal/cloud` service) handles user onboarding, role management, and invitation/activation flows.
 - API endpoints to list/update org members (usable by future UI/CLI commands).
 
 Tests
+
 - Unit tests for storage layer (CRUD operations, invitation acceptance).
 - Broker integration tests verifying `rocketship login` seeds default org and rewrites token claims accordingly.
 
 Manual tests
+
 - Create org, invite additional GitHub usernames, login as invitee, ensure token carries correct org/role.
 
 ---
@@ -82,14 +93,17 @@ Manual tests
 ## PR 4 — Docs & Onboarding Experience
 
 **What it accomplishes**
+
 - Updates documentation for the new hosted product, including sign-up flow, CLI login, RBAC basics, and enterprise overrides.
 
 **Changes**
+
 - Cloud quick start: register, `rocketship login`, run tests, view results.
 - Enterprise and self-hosted guides updated to describe using the broker vs BYO IdP (Okta/Auth0/Azure). Include `rbac.yaml`/Terraform seeding instructions for self-hosted.
 - CLI help text references GitHub login.
 
 **Tests**
+
 - Documentation build (mkdocs) passes.
 - CLI help text references GitHub login.
 

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -33,7 +33,7 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 - Add `internal/authbroker/` service and `cmd/authbroker` entrypoint (Go) with endpoints: `/device/code`, `/token`, `/refresh`, `/.well-known/jwks.json`.
 - JWT signer backed by RSA/ECDSA key; refresh token store encrypted at rest (file for dev, KMS/Vault later).
 - Helm templates for broker Deployment/Service/ConfigMap, and engine env var wiring when GitHub mode is enabled.
-- Usage preset `charts/rocketship/values-github-cloud.yaml` (or update `values-oidc-web.yaml`) pointing to the broker.
+- Usage preset `charts/rocketship/values-github-globalbank.yaml` (or update `values-oidc-web.yaml`) pointing to the broker.
 
 **Tests / validation**
 - Unit tests for broker endpoints with mocked GitHub responses.

--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -23,44 +23,26 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 
 ---
 
-## PR 1 — GitHub Auth Broker
+## PR 1 — GitHub Auth Broker + Helm Integration
 
 **What it accomplishes**
 - Implements an HTTP service that proxies the OAuth 2.0 Device Authorization Grant to GitHub and returns Rocketship-signed JWTs + refresh tokens.
-- Exposes JWKS so engines can validate tokens locally.
+- Deploys the broker alongside the engine via Helm and wires engines to the broker endpoints when `auth.oidc.mode=github`.
 
 **Changes**
-- Add `internal/broker/` service (Go) with endpoints: `/device/code`, `/token`, `/refresh`, `/.well-known/jwks.json`.
+- Add `internal/authbroker/` service and `cmd/authbroker` entrypoint (Go) with endpoints: `/device/code`, `/token`, `/refresh`, `/.well-known/jwks.json`.
 - JWT signer backed by RSA/ECDSA key; refresh token store encrypted at rest (file for dev, KMS/Vault later).
-- Unit tests covering device exchange and refresh paths using GitHub mocks.
+- Helm templates for broker Deployment/Service/ConfigMap, and engine env var wiring when GitHub mode is enabled.
+- Usage preset `charts/rocketship/values-github-cloud.yaml` (or update `values-oidc-web.yaml`) pointing to the broker.
 
-**CI integration**
-- New workflow running broker unit tests (`go test ./internal/broker`).
-
-**Manual tests**
-- Local: run broker + CLI against GitHub staging credentials, confirm `rocketship login` obtains Rocketship JWTs.
-
----
-
-## PR 2 — Broker Helm Integration
-
-**What it accomplishes**
-- Deploys the broker alongside the engine in the Rocketship chart and wires engine env vars to broker endpoints when `auth.oidc.mode=github`.
-
-**Changes**
-- Chart templates: broker deployment/service, optional ingress, secrets for GitHub client ID/secret.
-- Engine values accept new keys: `auth.oidc.mode`, `auth.oidc.github.clients[*]`, etc.
-- Default `values-oidc-web.yaml` updated to target broker instead of Auth0 for the usage-based preset.
-
-**Tests**
-- `helm_template_check.sh` renders chart with broker enabled and asserts env vars match the broker endpoints, JWKS URL, etc.
-
-**Manual tests**
-- Deploy chart to DO cluster with broker enabled, confirm engine discovery advertises broker endpoints.
+**Tests / validation**
+- Unit tests for broker endpoints with mocked GitHub responses.
+- `helm_template_check.sh` renders chart with `auth.oidc.mode=github` and asserts broker and engine env vars.
+- Manual validation: deploy broker + chart to DO cluster, run `rocketship login` + `rocketship run` end-to-end.
 
 ---
 
-## PR 3 — RBAC Claim Enforcement
+## PR 2 — RBAC Claim Enforcement
 
 **What it accomplishes**
 - Establishes a minimal role model (`owner/admin/editor/viewer/service_account`), adds claim parsing to the engine, and blocks unauthorized RPCs (e.g., viewers cannot create runs).
@@ -79,25 +61,25 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 
 ---
 
-## PR 4 — Cloud Org & Role Persistence
+## PR 3 — Cloud Org & Role Persistence
 
-**What it accomplishes**
+What it accomplishes
 - Introduces a lightweight persistence layer (Postgres table or Redis) for users, organisations, memberships, invitations, and role assignments.
 
-**Changes**
+Changes
 - Broker (or new `internal/cloud` service) handles user onboarding, role management, and invitation/activation flows.
 - API endpoints to list/update org members (usable by future UI/CLI commands).
 
-**Tests**
+Tests
 - Unit tests for storage layer (CRUD operations, invitation acceptance).
 - Broker integration tests verifying `rocketship login` seeds default org and rewrites token claims accordingly.
 
-**Manual tests**
+Manual tests
 - Create org, invite additional GitHub usernames, login as invitee, ensure token carries correct org/role.
 
 ---
 
-## PR 5 — Docs & Onboarding Experience
+## PR 4 — Docs & Onboarding Experience
 
 **What it accomplishes**
 - Updates documentation for the new hosted product, including sign-up flow, CLI login, RBAC basics, and enterprise overrides.
@@ -105,6 +87,7 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 **Changes**
 - Cloud quick start: register, `rocketship login`, run tests, view results.
 - Enterprise and self-hosted guides updated to describe using the broker vs BYO IdP (Okta/Auth0/Azure). Include `rbac.yaml`/Terraform seeding instructions for self-hosted.
+- CLI help text references GitHub login.
 
 **Tests**
 - Documentation build (mkdocs) passes.
@@ -118,4 +101,3 @@ Deliver a production-ready, usage-based Rocketship Cloud offering where customer
 - Web UI for org/role management and billing integration.
 - Audit log streaming and webhook events.
 - Fine-grained project-level permissions.
-

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build-binaries: prepare-embed
 	@echo "Building embedded binaries..."
 	@go build -o internal/embedded/bin/worker cmd/worker/main.go
 	@go build -o internal/embedded/bin/engine cmd/engine/main.go
+	@go build -o internal/embedded/bin/auth-broker cmd/authbroker/main.go
 
 # Build the CLI with embedded binaries
 build: build-binaries

--- a/charts/rocketship/templates/_helpers.tpl
+++ b/charts/rocketship/templates/_helpers.tpl
@@ -44,3 +44,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "rocketship.webProxy.fullname" -}}
 {{- printf "%s-web-oauth2-proxy" (include "rocketship.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "rocketship.authbroker.fullname" -}}
+{{- printf "%s-auth-broker" (include "rocketship.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/rocketship/templates/authbroker-deployment.yaml
+++ b/charts/rocketship/templates/authbroker-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.auth.broker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rocketship.authbroker.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketship.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: auth-broker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rocketship.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: auth-broker
+    spec:
+      containers:
+        - name: broker
+          image: "{{ .Values.auth.broker.image.repository }}:{{ .Values.auth.broker.image.tag }}"
+          imagePullPolicy: {{ .Values.auth.broker.image.pullPolicy }}
+          env:
+            - name: ROCKETSHIP_BROKER_LISTEN_ADDR
+              value: ":{{ .Values.auth.broker.service.port }}"
+            {{- $issuer := default .Values.auth.oidc.issuer .Values.auth.broker.issuer }}
+            {{- if $issuer }}
+            - name: ROCKETSHIP_BROKER_ISSUER
+              value: {{ $issuer | quote }}
+            {{- end }}
+            {{- $aud := default .Values.auth.oidc.audience .Values.auth.broker.audience }}
+            {{- if $aud }}
+            - name: ROCKETSHIP_BROKER_AUDIENCE
+              value: {{ $aud | quote }}
+            {{- end }}
+            {{- $client := default .Values.auth.oidc.clientID .Values.auth.broker.clientID }}
+            {{- if $client }}
+            - name: ROCKETSHIP_BROKER_CLIENT_ID
+              value: {{ $client | quote }}
+            {{- end }}
+            - name: ROCKETSHIP_BROKER_SIGNING_KEY_FILE
+              value: {{ printf "%s/%s" .Values.auth.broker.signingKey.mountPath .Values.auth.broker.signingKey.fileName | quote }}
+            - name: ROCKETSHIP_BROKER_STORE_PATH
+              value: {{ .Values.auth.broker.store.path | quote }}
+            {{- $scopes := default .Values.auth.oidc.scopes .Values.auth.broker.scopes }}
+            {{- if $scopes }}
+            - name: ROCKETSHIP_BROKER_SCOPES
+              value: {{ join " " $scopes | quote }}
+            {{- end }}
+            {{- if .Values.auth.broker.github.clientID }}
+            - name: ROCKETSHIP_GITHUB_CLIENT_ID
+              value: {{ .Values.auth.broker.github.clientID | quote }}
+            {{- end }}
+            {{- if .Values.auth.broker.github.scopes }}
+            - name: ROCKETSHIP_GITHUB_SCOPES
+              value: {{ join " " .Values.auth.broker.github.scopes | quote }}
+            {{- end }}
+            {{- range .Values.auth.broker.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- $hasSecrets := or .Values.auth.broker.github.clientSecretSecret .Values.auth.broker.store.encryptionKeySecret }}
+          {{- if or (gt (len .Values.auth.broker.envFrom) 0) $hasSecrets }}
+          envFrom:
+            {{- if .Values.auth.broker.envFrom }}
+            {{ toYaml .Values.auth.broker.envFrom | nindent 12 }}
+            {{- end }}
+            {{- if .Values.auth.broker.github.clientSecretSecret }}
+            - secretRef:
+                name: {{ .Values.auth.broker.github.clientSecretSecret }}
+            {{- end }}
+            {{- if .Values.auth.broker.store.encryptionKeySecret }}
+            - secretRef:
+                name: {{ .Values.auth.broker.store.encryptionKeySecret }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.auth.broker.service.port }}
+              protocol: TCP
+          volumeMounts:
+            {{- if .Values.auth.broker.signingKey.secretName }}
+            - name: broker-signing-key
+              mountPath: {{ .Values.auth.broker.signingKey.mountPath }}
+              readOnly: true
+            {{- end }}
+            - name: broker-store
+              mountPath: {{ .Values.auth.broker.store.mountPath }}
+          {{- with .Values.auth.broker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- if .Values.auth.broker.signingKey.secretName }}
+        - name: broker-signing-key
+          secret:
+            secretName: {{ .Values.auth.broker.signingKey.secretName }}
+            items:
+              - key: {{ .Values.auth.broker.signingKey.key }}
+                path: {{ .Values.auth.broker.signingKey.fileName }}
+        {{- end }}
+        - name: broker-store
+          {{- if and (not .Values.auth.broker.store.emptyDir) .Values.auth.broker.store.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.auth.broker.store.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.auth.broker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.broker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.broker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/rocketship/templates/authbroker-ingress.yaml
+++ b/charts/rocketship/templates/authbroker-ingress.yaml
@@ -1,0 +1,37 @@
+{{- $broker := .Values.auth.broker -}}
+{{- if and $broker.enabled $broker.ingress $broker.ingress.enabled }}
+{{- $fullName := include "rocketship.authbroker.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+  {{- with $broker.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $broker.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $broker.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $broker.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $broker.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/rocketship/templates/authbroker-service.yaml
+++ b/charts/rocketship/templates/authbroker-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.auth.broker.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rocketship.authbroker.fullname" . }}
+  labels:
+    {{- include "rocketship.labels" . | nindent 4 }}
+  {{- with .Values.auth.broker.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.auth.broker.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "rocketship.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: auth-broker
+  ports:
+    - name: http
+      port: {{ .Values.auth.broker.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/rocketship/templates/engine-deployment.yaml
+++ b/charts/rocketship/templates/engine-deployment.yaml
@@ -43,36 +43,49 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-            {{- if .Values.auth.oidc.enabled }}
+            {{- $oidcMode := .Values.auth.oidc.mode | default .Values.auth.mode }}
+            {{- $modeLower := lower $oidcMode }}
+            {{- $oidcEnabled := or .Values.auth.oidc.enabled (or (eq $modeLower "github") (eq $modeLower "oidc")) }}
+            {{- if $oidcEnabled }}
             - name: ROCKETSHIP_AUTH_MODE
               value: "oidc"
-            {{- if .Values.auth.oidc.issuer }}
+            {{- $issuer := coalesce .Values.auth.oidc.issuer .Values.auth.broker.issuer }}
+            {{- if $issuer }}
             - name: ROCKETSHIP_OIDC_ISSUER
-              value: {{ .Values.auth.oidc.issuer | quote }}
+              value: {{ $issuer | quote }}
             {{- end }}
-            {{- if .Values.auth.oidc.clientID }}
+            {{- $clientID := coalesce .Values.auth.oidc.clientID .Values.auth.broker.clientID }}
+            {{- if $clientID }}
             - name: ROCKETSHIP_OIDC_CLIENT_ID
-              value: {{ .Values.auth.oidc.clientID | quote }}
+              value: {{ $clientID | quote }}
             {{- end }}
-            {{- if .Values.auth.oidc.audience }}
+            {{- $audience := coalesce .Values.auth.oidc.audience .Values.auth.broker.audience }}
+            {{- if $audience }}
             - name: ROCKETSHIP_OIDC_AUDIENCE
-              value: {{ .Values.auth.oidc.audience | quote }}
+              value: {{ $audience | quote }}
             {{- end }}
-            {{- if .Values.auth.oidc.tokenEndpoint }}
-            - name: ROCKETSHIP_OIDC_TOKEN_ENDPOINT
-              value: {{ .Values.auth.oidc.tokenEndpoint | quote }}
-            {{- end }}
-            {{- if .Values.auth.oidc.deviceEndpoint }}
+            {{- $brokerHost := printf "http://%s:%v" (include "rocketship.authbroker.fullname" .) .Values.auth.broker.service.port }}
+            {{- $deviceEndpoint := coalesce .Values.auth.oidc.deviceEndpoint (ternary (printf "%s/device/code" $brokerHost) "" (eq $modeLower "github")) }}
+            {{- if $deviceEndpoint }}
             - name: ROCKETSHIP_OIDC_DEVICE_ENDPOINT
-              value: {{ .Values.auth.oidc.deviceEndpoint | quote }}
+              value: {{ $deviceEndpoint | quote }}
             {{- end }}
-            {{- if .Values.auth.oidc.jwksURL }}
+            {{- $tokenEndpoint := coalesce .Values.auth.oidc.tokenEndpoint (ternary (printf "%s/token" $brokerHost) "" (eq $modeLower "github")) }}
+            {{- if $tokenEndpoint }}
+            - name: ROCKETSHIP_OIDC_TOKEN_ENDPOINT
+              value: {{ $tokenEndpoint | quote }}
+            {{- end }}
+            {{- $jwksEndpoint := coalesce .Values.auth.oidc.jwksURL (ternary (printf "%s/.well-known/jwks.json" $brokerHost) "" (eq $modeLower "github")) }}
+            {{- if $jwksEndpoint }}
             - name: ROCKETSHIP_OIDC_JWKS_URL
-              value: {{ .Values.auth.oidc.jwksURL | quote }}
+              value: {{ $jwksEndpoint | quote }}
             {{- end }}
             {{- if .Values.auth.oidc.scopes }}
             - name: ROCKETSHIP_OIDC_SCOPES
               value: {{ join " " .Values.auth.oidc.scopes | quote }}
+            {{- else if .Values.auth.broker.scopes }}
+            - name: ROCKETSHIP_OIDC_SCOPES
+              value: {{ join " " .Values.auth.broker.scopes | quote }}
             {{- end }}
             {{- if .Values.auth.oidc.allowedAlgorithms }}
             - name: ROCKETSHIP_OIDC_ALLOWED_ALGS

--- a/charts/rocketship/values-github-cloud.yaml
+++ b/charts/rocketship/values-github-cloud.yaml
@@ -1,38 +1,30 @@
-# Preset values for the usage-based Rocketship Cloud deployment leveraging the GitHub auth broker.
-# These values assume you create the following Kubernetes secrets in the target namespace:
-#   rocketship-auth-broker-signing : contains key `signing-key.pem` with the PEM encoded private key used to sign JWTs
-#   rocketship-auth-broker-store   : contains key `ROCKETSHIP_BROKER_STORE_KEY` with a base64 encoded 32-byte encryption key
-#   rocketship-github-oauth   : contains keys `ROCKETSHIP_GITHUB_CLIENT_SECRET` (GitHub OAuth client secret) and optionally `ROCKETSHIP_GITHUB_CLIENT_ID`
-# Adjust hostnames and client identifiers to match your environment.
-
 auth:
   mode: oidc
   oidc:
     mode: github
-    issuer: https://cli.rocketship.sh
+    issuer: https://auth.rocketship.sh
     clientID: rocketship-cli
     audience: rocketship-cli
+    deviceEndpoint: https://auth.rocketship.sh/device/code
+    tokenEndpoint: https://auth.rocketship.sh/token
+    jwksURL: https://auth.rocketship.sh/.well-known/jwks.json
     scopes:
-      - openid
-      - profile
-      - email
-      - offline_access
+    - read:user
+    - user:email
   broker:
     enabled: true
-    issuer: https://cli.rocketship.sh
+    issuer: https://auth.rocketship.sh
     audience: rocketship-cli
     clientID: rocketship-cli
     scopes:
-      - openid
-      - profile
-      - email
-      - offline_access
+    - read:user
+    - user:email
     github:
-      clientID: your-github-oauth-client-id
+      clientID: Ov23li6jRbnoviVURzs9
       clientSecretSecret: rocketship-github-oauth
       scopes:
-        - read:user
-        - user:email
+      - read:user
+      - user:email
     signingKey:
       secretName: rocketship-auth-broker-signing
       key: signing-key.pem
@@ -45,27 +37,44 @@ auth:
       encryptionKeyKey: ROCKETSHIP_BROKER_STORE_KEY
       emptyDir: true
     env:
-      - name: ROCKETSHIP_BROKER_ACCESS_TTL
-        value: 15m
-      - name: ROCKETSHIP_BROKER_REFRESH_TTL
-        value: 720h
+    - name: ROCKETSHIP_BROKER_ACCESS_TTL
+      value: 15m
+    - name: ROCKETSHIP_BROKER_REFRESH_TTL
+      value: 720h
     service:
       type: ClusterIP
       port: 8080
-
+    ingress:
+      enabled: true
+      className: nginx
+      annotations: {}
+      hosts:
+      - host: auth.rocketship.sh
+        paths:
+        - path: /
+          pathType: Prefix
+      tls:
+      - secretName: rocketship-cloud-tls
+        hosts:
+        - auth.rocketship.sh
+    envFrom:
+    - secretRef:
+        name: rocketship-github-oauth
+    - secretRef:
+        name: rocketship-auth-broker-store
 ingress:
   enabled: true
   className: nginx
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: '0'
   hosts:
-    - host: cli.rocketship.sh
-      paths:
-        - path: /
-          pathType: Prefix
+  - host: cli.rocketship.sh
+    paths:
+    - path: /
+      pathType: Prefix
   tls:
-    - secretName: rocketship-cloud-tls
-      hosts:
-        - cli.rocketship.sh
+  - secretName: rocketship-cloud-tls
+    hosts:
+    - cli.rocketship.sh

--- a/charts/rocketship/values-github-cloud.yaml
+++ b/charts/rocketship/values-github-cloud.yaml
@@ -2,27 +2,30 @@ auth:
   mode: oidc
   oidc:
     mode: github
-    issuer: https://auth.rocketship.sh
+    issuer: https://auth.rocketship.globalbank.com
     clientID: rocketship-cli
     audience: rocketship-cli
-    deviceEndpoint: https://auth.rocketship.sh/device/code
-    tokenEndpoint: https://auth.rocketship.sh/token
-    jwksURL: https://auth.rocketship.sh/.well-known/jwks.json
+    deviceEndpoint: https://auth.rocketship.globalbank.com/device/code
+    tokenEndpoint: https://auth.rocketship.globalbank.com/token
+    jwksURL: https://auth.rocketship.globalbank.com/.well-known/jwks.json
     scopes:
+    - read:org
     - read:user
     - user:email
   broker:
     enabled: true
-    issuer: https://auth.rocketship.sh
+    issuer: https://auth.rocketship.globalbank.com
     audience: rocketship-cli
     clientID: rocketship-cli
     scopes:
+    - read:org
     - read:user
     - user:email
     github:
       clientID: Ov23li6jRbnoviVURzs9
       clientSecretSecret: rocketship-github-oauth
       scopes:
+      - read:org
       - read:user
       - user:email
     signingKey:
@@ -49,14 +52,14 @@ auth:
       className: nginx
       annotations: {}
       hosts:
-      - host: auth.rocketship.sh
+      - host: auth.rocketship.globalbank.com
         paths:
         - path: /
           pathType: Prefix
       tls:
       - secretName: rocketship-cloud-tls
         hosts:
-        - auth.rocketship.sh
+        - auth.rocketship.globalbank.com
     envFrom:
     - secretRef:
         name: rocketship-github-oauth
@@ -70,11 +73,11 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
     nginx.ingress.kubernetes.io/proxy-body-size: '0'
   hosts:
-  - host: cli.rocketship.sh
+  - host: cli.rocketship.globalbank.com
     paths:
     - path: /
       pathType: Prefix
   tls:
   - secretName: rocketship-cloud-tls
     hosts:
-    - cli.rocketship.sh
+    - cli.rocketship.globalbank.com

--- a/charts/rocketship/values-github-cloud.yaml
+++ b/charts/rocketship/values-github-cloud.yaml
@@ -1,0 +1,71 @@
+# Preset values for the usage-based Rocketship Cloud deployment leveraging the GitHub auth broker.
+# These values assume you create the following Kubernetes secrets in the target namespace:
+#   rocketship-auth-broker-signing : contains key `signing-key.pem` with the PEM encoded private key used to sign JWTs
+#   rocketship-auth-broker-store   : contains key `ROCKETSHIP_BROKER_STORE_KEY` with a base64 encoded 32-byte encryption key
+#   rocketship-github-oauth   : contains keys `ROCKETSHIP_GITHUB_CLIENT_SECRET` (GitHub OAuth client secret) and optionally `ROCKETSHIP_GITHUB_CLIENT_ID`
+# Adjust hostnames and client identifiers to match your environment.
+
+auth:
+  mode: oidc
+  oidc:
+    mode: github
+    issuer: https://cli.rocketship.sh
+    clientID: rocketship-cli
+    audience: rocketship-cli
+    scopes:
+      - openid
+      - profile
+      - email
+      - offline_access
+  broker:
+    enabled: true
+    issuer: https://cli.rocketship.sh
+    audience: rocketship-cli
+    clientID: rocketship-cli
+    scopes:
+      - openid
+      - profile
+      - email
+      - offline_access
+    github:
+      clientID: your-github-oauth-client-id
+      clientSecretSecret: rocketship-github-oauth
+      scopes:
+        - read:user
+        - user:email
+    signingKey:
+      secretName: rocketship-auth-broker-signing
+      key: signing-key.pem
+      mountPath: /var/run/rocketship
+      fileName: signing-key.pem
+    store:
+      path: /var/lib/rocketship/broker-store.enc
+      mountPath: /var/lib/rocketship
+      encryptionKeySecret: rocketship-auth-broker-store
+      encryptionKeyKey: ROCKETSHIP_BROKER_STORE_KEY
+      emptyDir: true
+    env:
+      - name: ROCKETSHIP_BROKER_ACCESS_TTL
+        value: 15m
+      - name: ROCKETSHIP_BROKER_REFRESH_TTL
+        value: 720h
+    service:
+      type: ClusterIP
+      port: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  hosts:
+    - host: cli.rocketship.sh
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: rocketship-cloud-tls
+      hosts:
+        - cli.rocketship.sh

--- a/charts/rocketship/values-github-globalbank.yaml
+++ b/charts/rocketship/values-github-globalbank.yaml
@@ -22,21 +22,21 @@ auth:
     - read:user
     - user:email
     github:
-      clientID: Ov23li6jRbnoviVURzs9
-      clientSecretSecret: rocketship-github-oauth
+      clientID: your-github-client-id
+      clientSecretSecret: globalbank-github-oauth
       scopes:
       - read:org
       - read:user
       - user:email
     signingKey:
-      secretName: rocketship-auth-broker-signing
+      secretName: globalbank-auth-broker-signing
       key: signing-key.pem
       mountPath: /var/run/rocketship
       fileName: signing-key.pem
     store:
       path: /var/lib/rocketship/broker-store.enc
       mountPath: /var/lib/rocketship
-      encryptionKeySecret: rocketship-auth-broker-store
+      encryptionKeySecret: globalbank-auth-broker-store
       encryptionKeyKey: ROCKETSHIP_BROKER_STORE_KEY
       emptyDir: true
     env:
@@ -57,14 +57,14 @@ auth:
         - path: /
           pathType: Prefix
       tls:
-      - secretName: rocketship-cloud-tls
+      - secretName: globalbank-tls
         hosts:
         - auth.rocketship.globalbank.com
     envFrom:
     - secretRef:
-        name: rocketship-github-oauth
+        name: globalbank-github-oauth
     - secretRef:
-        name: rocketship-auth-broker-store
+        name: globalbank-auth-broker-store
 ingress:
   enabled: true
   className: nginx
@@ -78,6 +78,6 @@ ingress:
     - path: /
       pathType: Prefix
   tls:
-  - secretName: rocketship-cloud-tls
+  - secretName: globalbank-tls
     hosts:
     - cli.rocketship.globalbank.com

--- a/charts/rocketship/values-oidc-web.yaml
+++ b/charts/rocketship/values-oidc-web.yaml
@@ -22,7 +22,7 @@ web:
           - path: /
             pathType: Prefix
     tls:
-      - secretName: rocketship-cloud-tls
+      - secretName: globalbank-tls
         hosts:
           - app.rocketship.globalbank.com
   oauth2Proxy:

--- a/charts/rocketship/values-oidc-web.yaml
+++ b/charts/rocketship/values-oidc-web.yaml
@@ -1,10 +1,10 @@
 # Example values for enabling oauth2-proxy in front of the Rocketship web endpoints
 # This configuration assumes:
-# - An Auth0 (or compatible OIDC) application configured for the Rocketship web UI
+# - A GitHub OAuth application configured for the Rocketship web UI (same app as the CLI device flow)
 # - A Kubernetes secret named `oauth2-proxy-credentials` with keys:
 #     clientID          -> OAuth client ID (plain text)
 #     clientSecret      -> OAuth client secret
-#     cookieSecret      -> 32-byte random string, base64 encoded (e.g. `python -c "import secrets, base64; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())"`)
+#     cookieSecret      -> 16-byte random string (hex or base64)
 # - The Rocketship engine service will serve HTTP traffic (health/UI) on port 7701
 
 web:
@@ -17,14 +17,14 @@ web:
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     hosts:
-      - host: app.globalbank.rocketship.sh
+      - host: app.rocketship.sh
         paths:
           - path: /
             pathType: Prefix
     tls:
-      - secretName: globalbank-rocketship-tls
+      - secretName: rocketship-cloud-tls
         hosts:
-          - app.globalbank.rocketship.sh
+          - app.rocketship.sh
   oauth2Proxy:
     enabled: true
     replicaCount: 1
@@ -39,7 +39,7 @@ web:
       - --skip-provider-button=true
     env:
       - name: OAUTH2_PROXY_PROVIDER
-        value: oidc
+        value: github
       - name: OAUTH2_PROXY_CLIENT_ID
         valueFrom:
           secretKeyRef:
@@ -56,11 +56,7 @@ web:
             name: oauth2-proxy-credentials
             key: cookieSecret
       - name: OAUTH2_PROXY_REDIRECT_URL
-        value: https://app.globalbank.rocketship.sh/oauth2/callback
-      - name: OAUTH2_PROXY_OIDC_ISSUER_URL
-        value: https://dev-0ankenxegmh7xfjm.us.auth0.com/ # e.g. https://rocketship-demo.us.auth0.com/
-      - name: OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL
-        value: "false"
+        value: https://app.rocketship.sh/oauth2/callback
       - name: OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER
         value: "true"
       - name: OAUTH2_PROXY_SET_AUTHORIZATION_HEADER
@@ -72,18 +68,11 @@ web:
       - name: OAUTH2_PROXY_HTTPS_ADDRESS
         value: ":0"
 
+      - name: OAUTH2_PROXY_SCOPE
+        value: "read:user user:email"
+      - name: OAUTH2_PROXY_EMAIL_DOMAINS
+        value: "*"
+
 auth:
   oidc:
-    enabled: true
-    issuer: https://dev-0ankenxegmh7xfjm.us.auth0.com/
-    clientID: rocketship-cli
-    tokenEndpoint: https://dev-0ankenxegmh7xfjm.us.auth0.com/oauth/token
-    deviceEndpoint: https://dev-0ankenxegmh7xfjm.us.auth0.com/oauth/device/code
-    jwksURL: https://dev-0ankenxegmh7xfjm.us.auth0.com/.well-known/jwks.json
-    scopes:
-      - openid
-      - profile
-      - email
-      - offline_access
-    allowedAlgorithms:
-      - RS256
+    enabled: false

--- a/charts/rocketship/values-oidc-web.yaml
+++ b/charts/rocketship/values-oidc-web.yaml
@@ -17,14 +17,14 @@ web:
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     hosts:
-      - host: app.rocketship.sh
+      - host: app.rocketship.globalbank.com
         paths:
           - path: /
             pathType: Prefix
     tls:
       - secretName: rocketship-cloud-tls
         hosts:
-          - app.rocketship.sh
+          - app.rocketship.globalbank.com
   oauth2Proxy:
     enabled: true
     replicaCount: 1
@@ -56,7 +56,7 @@ web:
             name: oauth2-proxy-credentials
             key: cookieSecret
       - name: OAUTH2_PROXY_REDIRECT_URL
-        value: https://app.rocketship.sh/oauth2/callback
+        value: https://app.rocketship.globalbank.com/oauth2/callback
       - name: OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER
         value: "true"
       - name: OAUTH2_PROXY_SET_AUTHORIZATION_HEADER

--- a/charts/rocketship/values-production.yaml
+++ b/charts/rocketship/values-production.yaml
@@ -7,11 +7,11 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   hosts:
-    - host: cli.globalbank.rocketship.sh
+    - host: cli.rocketship.sh
       paths:
         - path: /
           pathType: Prefix
   tls:
-    - secretName: globalbank-rocketship-tls
+    - secretName: rocketship-cloud-tls
       hosts:
-        - cli.globalbank.rocketship.sh
+        - cli.rocketship.sh

--- a/charts/rocketship/values-production.yaml
+++ b/charts/rocketship/values-production.yaml
@@ -12,6 +12,6 @@ ingress:
         - path: /
           pathType: Prefix
   tls:
-    - secretName: rocketship-cloud-tls
+    - secretName: globalbank-tls
       hosts:
-    - cli.rocketship.globalbank.com
+        - cli.rocketship.globalbank.com

--- a/charts/rocketship/values-production.yaml
+++ b/charts/rocketship/values-production.yaml
@@ -7,11 +7,11 @@ ingress:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   hosts:
-    - host: cli.rocketship.sh
+    - host: cli.rocketship.globalbank.com
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: rocketship-cloud-tls
       hosts:
-        - cli.rocketship.sh
+    - cli.rocketship.globalbank.com

--- a/charts/rocketship/values.yaml
+++ b/charts/rocketship/values.yaml
@@ -21,8 +21,10 @@ temporal:
   namespace: "default"
 
 auth:
+  mode: ""
   oidc:
     enabled: false
+    mode: ""
     issuer: ""
     clientID: ""
     audience: ""
@@ -31,6 +33,43 @@ auth:
     jwksURL: ""
     scopes: []
     allowedAlgorithms: []
+  broker:
+    enabled: false
+    image:
+      repository: rocketshipai/rocketship-auth-broker
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 8080
+      annotations: {}
+    issuer: ""
+    audience: ""
+    clientID: ""
+    scopes: []
+    github:
+      clientID: ""
+      clientSecretSecret: ""
+      clientSecretKey: github-client-secret
+      scopes: []
+    signingKey:
+      secretName: ""
+      key: signing-key.pem
+      mountPath: /var/run/rocketship
+      fileName: signing-key.pem
+    store:
+      path: /var/lib/rocketship/broker-store.enc
+      mountPath: /var/lib/rocketship
+      encryptionKeySecret: ""
+      encryptionKeyKey: broker-store-key
+      emptyDir: true
+      existingClaim: ""
+    env: []
+    envFrom: []
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
 
 engine:
   replicaCount: 1

--- a/cmd/authbroker/main.go
+++ b/cmd/authbroker/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	authbroker "github.com/rocketship-ai/rocketship/internal/authbroker"
+)
+
+func main() {
+	cfg, err := authbroker.LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("broker configuration error: %v", err)
+	}
+
+	srv, err := authbroker.NewServer(cfg)
+	if err != nil {
+		log.Fatalf("failed to initialise broker: %v", err)
+	}
+
+	server := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           loggingMiddleware(srv),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Printf("broker shutdown error: %v", err)
+		}
+	}()
+
+	log.Printf("rocketship auth broker listening on %s", cfg.ListenAddr)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("broker server error: %v", err)
+	}
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(lrw, r)
+		log.Printf("%s %s %d %s", r.Method, r.URL.Path, lrw.status, time.Since(start))
+	})
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (l *loggingResponseWriter) WriteHeader(statusCode int) {
+	l.status = statusCode
+	l.ResponseWriter.WriteHeader(statusCode)
+}

--- a/docs/src/deploy-on-your-cloud.md
+++ b/docs/src/deploy-on-your-cloud.md
@@ -20,7 +20,7 @@ Both Rocketship services require the Temporal frontend host and namespace; every
 | --- | --- | --- |
 | Local iteration | [Run on Minikube](deploy/minikube.md) | Single script (`scripts/install-minikube.sh`) that starts Minikube, installs Temporal, builds local engine/worker images, and deploys the Rocketship chart. Great for fast feedback and integration testing inside CI. |
 | Production-ready proof of concept | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md) | Walks through preparing a managed cluster, wiring an NGINX ingress with TLS, publishing custom images to DigitalOcean Container Registry, and installing the Rocketship + Temporal Helm releases. |
-| Web UI with OIDC front-door | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md#7-enable-oidc-for-the-web-ui-optional) | Layer oauth2-proxy + NGINX annotations using `values-oidc-web.yaml`, fronting `app.globalbank.rocketship.sh` while gRPC traffic stays on `globalbank.rocketship.sh`. |
+| Web UI with OIDC front-door | [Deploy on DigitalOcean Kubernetes](deploy/digitalocean.md#7-enable-oidc-for-the-web-ui-optional) | Layer oauth2-proxy + NGINX annotations using `values-oidc-web.yaml`, fronting `app.rocketship.globalbank.com` while gRPC traffic stays on `cli.rocketship.globalbank.com`. |
 
 > Looking for another cloud? The DigitalOcean flow covers all building blocks: registry authentication, TLS secrets, ingress, and chart overrides. Adapt the same pattern for EKS, GKE, AKS, or on-prem clusters by swapping provider-specific commands.
 

--- a/docs/src/deploy/digitalocean.md
+++ b/docs/src/deploy/digitalocean.md
@@ -108,6 +108,13 @@ docker buildx build \
   -f .docker/Dockerfile.worker \
   -t $REGISTRY/rocketship-worker:$TAG . \
   --push
+
+# Auth broker
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -f .docker/Dockerfile.authbroker \
+  -t $REGISTRY/rocketship-auth-broker:$TAG . \
+  --push
 ```
 
 > Re-run these commands whenever you change code; keep the tag stable (for example `v0.1-test`) so the Helm release pulls the updated digest.
@@ -132,8 +139,8 @@ helm install rocketship charts/rocketship \
   --set ingress.annotations."nginx\.ingress\.kubernetes\.io/ssl-redirect"="true" \
   --set ingress.annotations."nginx\.ingress\.kubernetes\.io/proxy-body-size"="0" \
   --set ingress.tls[0].secretName=globalbank-rocketship-tls \
-  --set ingress.tls[0].hosts[0]=globalbank.rocketship.sh \
-  --set ingress.hosts[0].host=globalbank.rocketship.sh \
+  --set ingress.tls[0].hosts[0]=cli.globalbank.rocketship.sh \
+  --set ingress.hosts[0].host=cli.globalbank.rocketship.sh \
   --set ingress.hosts[0].paths[0].path=/ \
   --set ingress.hosts[0].paths[0].pathType=Prefix \
   --wait
@@ -174,100 +181,78 @@ If you want browser users to authenticate via Auth0/Okta before reaching Rockets
      --wait
    ```
 
-4. **Verify the flow:** visit `https://app.globalbank.rocketship.sh/` in a fresh session. You should be redirected to Auth0, and after login you should land on the proxied Rocketship health page (`/healthz`). gRPC traffic remains on `globalbank.rocketship.sh:7700` and is expected to be protected with bearer tokens (see the next section).
+4. **Verify the flow:** visit `https://app.globalbank.rocketship.sh/` in a fresh session. You should be redirected to Auth0, and after login you should land on the proxied Rocketship health page (`/healthz`). gRPC traffic remains on `cli.globalbank.rocketship.sh:443` and is expected to be protected with JWTs minted by the broker (see the next section).
 
-## 8. Enable Token Authentication for gRPC (recommended)
+## 8. Configure GitHub Device Flow for the CLI (recommended)
 
-Issue a long-lived token for the engine so only authenticated CLI or CI jobs can invoke workflows.
+Usage-based Rocketship Cloud relies on the GitHub auth broker to mint Rocketship-signed JWTs. Configure it once and every developer can authenticate with `rocketship login`.
 
-1. **Generate a token and store it in a Kubernetes secret** (replace the example value):
+1. **Create the signing key secret.** Generate a 2048-bit RSA key (or reuse an existing one) and store it as `signing-key.pem`.
    ```bash
-   kubectl create secret generic rocketship-engine-token \
+   openssl genrsa -out signing-key.pem 2048
+   kubectl create secret generic rocketship-auth-broker-signing \
      --namespace rocketship \
-     --from-literal=token="rst_self_$(openssl rand -hex 32)"
+     --from-file=signing-key.pem
    ```
 
-2. **Patch your Helm values (or create `values-token.yaml`) to inject the token:**
-
-   ```yaml
-   engine:
-     env:
-       - name: ROCKETSHIP_ENGINE_TOKEN
-         valueFrom:
-           secretKeyRef:
-             name: rocketship-engine-token
-             key: token
+2. **Provision an encryption key for the refresh-token store.**
+   ```bash
+   python -c "import os,base64;print(base64.b64encode(os.urandom(32)).decode())" > broker-store.key
+   kubectl create secret generic rocketship-auth-broker-store \
+     --namespace rocketship \
+     --from-file=ROCKETSHIP_BROKER_STORE_KEY=broker-store.key
    ```
 
-   Apply it alongside the production values:
+3. **Create a GitHub OAuth App (device flow).**
+   - Homepage URL: `https://cli.rocketship.sh`
+   - Callback URL: `https://cli.rocketship.sh/oauth2/callback`
+   - Under *Device Flow*, enable **Allow device flow**.
+   - Copy the Client ID and Client Secret.
 
+4. **Store the GitHub client secret.**
+   ```bash
+   kubectl create secret generic rocketship-github-oauth \
+     --namespace rocketship \
+     --from-literal=ROCKETSHIP_GITHUB_CLIENT_SECRET=<github-client-secret>
+   ```
+
+5. **Deploy the chart with the GitHub preset.** Provide the GitHub Client ID while secrets keep everything sensitive out of the values file.
    ```bash
    helm upgrade --install rocketship charts/rocketship \
      --namespace rocketship \
      -f charts/rocketship/values-production.yaml \
-     -f values-token.yaml \
+     -f charts/rocketship/values-github-cloud.yaml \
+     --set engine.image.repository=$REGISTRY/rocketship-engine \
+     --set engine.image.tag=$TAG \
+     --set worker.image.repository=$REGISTRY/rocketship-worker \
+     --set worker.image.tag=$TAG \
+     --set auth.broker.github.clientID=<github-client-id> \
      --wait
    ```
 
-3. **Configure the CLI** by setting `ROCKETSHIP_TOKEN` before invoking commands or within your CI secret store:
-
+6. **Log in from the CLI.**
    ```bash
-   export ROCKETSHIP_TOKEN="rst_self_yourtoken"
-   rocketship list
+   rocketship profile create cloud grpcs://cli.rocketship.sh
+   rocketship profile use cloud
+   rocketship login
+   rocketship status
    ```
 
-   When the environment variable is absent, the CLI now returns a clear error instructing you to supply the token.
+   The CLI guides you through GitHub device flow (`https://github.com/login/device`), stores access + refresh tokens in the OS keyring, and automatically refreshes them on subsequent commands.
 
-> The token lives entirely in Kubernetes secrets and short-lived environment variables; no code changes are required in the chart. Rotate it by updating the secret and re-running the Helm upgrade.
+> The broker stores only hashed refresh tokens encrypted at rest. Rotate the signing key or store key by updating the Kubernetes secrets and rerunning `helm upgrade`.
 
-## 10. Point DNS at the Load Balancer
+## 9. Bring Your Own OIDC Provider (enterprise/self-hosted)
 
-Retrieve the ingress address and configure an A record for your domain:
+If your organisation mandates an internal IdP (Auth0, Okta, Azure AD, etc.), the chart still supports direct OIDC configuration without the GitHub broker. Provision two clients—one Native app for the CLI (device flow + refresh tokens) and one Regular Web Application for oauth2-proxy—and optionally an API/audience according to your provider’s terminology.
 
-```bash
-kubectl get ingress -n rocketship
-```
-
-For example, the ingress might resolve to `104.248.110.90`. Create an A record such as:
-
-| Host | Value |
-| --- | --- |
-| `globalbank` | `104.248.110.90` |
-
-Propagation is usually near-immediate within DigitalOcean DNS but may take longer with external registrars.
-
-## 9. Enable OIDC Authentication for CLI (optional)
-
-The Helm chart now ships a turn-key configuration that enables both the UI oauth2-proxy and the engine’s gRPC JWT validation. To use it with Auth0 (or a similar IdP), provision two clients and an API:
-
-1. **Create a custom API** (`Applications → APIs → Create API`). Any URL-style identifier works (e.g. `https://rocketship-engine`). Enable **Allow Offline Access** so the CLI can request refresh tokens.
-2. **Create or clone a Native application** for the CLI. Under *Advanced Settings → Grant Types* enable **Device Authorization** (Auth0 shows this only for Native apps) and **Refresh Token**. Then open the API you created in step 1, switch to **Machine to Machine Applications**, and authorise the Native client for the scopes you need (`openid profile email offline_access` etc.). Note the client ID.
-3. **Keep your existing Regular Web Application** (or oauth2-proxy client) for the UI. Its client ID/secret remain in the `oauth2-proxy-credentials` secret.
-
-With those pieces in place, edit `charts/rocketship/values-oidc-web.yaml` so `auth.oidc.*` matches your tenant (issuer, native client ID, audience/API identifier, and—if your IdP doesn’t expose discovery—explicit device/token/JWKS endpoints). Then deploy with the one-line command:
+Update `charts/rocketship/values-oidc-web.yaml` with your issuer, audience, and client IDs. Then deploy with both the production and OIDC presets:
 
 ```bash
-helm upgrade --install rocketship charts/rocketship \
-  --namespace rocketship \
-  -f charts/rocketship/values-production.yaml \
-  -f charts/rocketship/values-oidc-web.yaml \
-  --set engine.image.repository=$REGISTRY/rocketship-engine \
-  --set engine.image.tag=$TAG \
-  --set worker.image.repository=$REGISTRY/rocketship-worker \
-  --set worker.image.tag=$TAG \
-  --wait
+helm upgrade --install rocketship charts/rocketship   --namespace rocketship   -f charts/rocketship/values-production.yaml   -f charts/rocketship/values-oidc-web.yaml   --set engine.image.repository=$REGISTRY/rocketship-engine   --set engine.image.tag=$TAG   --set worker.image.repository=$REGISTRY/rocketship-worker   --set worker.image.tag=$TAG   --wait
 ```
 
-After rollout, each developer runs `rocketship login` once (device flow) and the CLI will attach validated JWTs to every gRPC call. If your IdP lacks discovery metadata, override `auth.oidc.deviceEndpoint`, `auth.oidc.tokenEndpoint`, and `auth.oidc.jwksURL` in the values file or via `--set` flags.
-
-After deploying, ask users to sign in once with the CLI:
-
-```bash
-rocketship login -p globalbank
-rocketship status            # confirm expiry and identity
-```
-
-The CLI stores access tokens securely and will refresh them as needed when contacting the engine.
+After rollout, developers run `rocketship login -p <profile>` to complete device flow against your IdP. The CLI persists the refresh token and renews access tokens automatically.
 
 ### RBAC considerations
 
@@ -278,14 +263,15 @@ Regardless of where Rocketship runs (cloud usage-based, dedicated enterprise, or
 3. **Role management lives in Rocketship.** Maintain an RBAC table in Rocketship Cloud (or the broker) so you can invite users, sync GitHub teams if desired, or import roles from customer IdPs. The engine only consumes the resulting claims; it doesn’t need to know whether they originated from GitHub, Okta, or internal configuration.
 4. **Future enhancements** (optional): provide an `rbac.yaml` or Terraform provider so self-hosted clusters can seed organisations/roles declaratively, and add UI to sync GitHub org/team membership if customers opt in.
 
-This approach lets you offer the same RBAC semantics in every environment. Usage-based customers can rely on the GitHub-backed broker, while enterprise tenants with their own IdP simply mint tokens that include the same claim set.
+This approach lets you offer the same RBAC semantics in every environment. Usage-based customers rely on the GitHub-backed broker, while enterprise tenants with their own IdP simply mint tokens that include the same claim set.
 
+## 10. Point DNS at the Load Balancer
 ## 11. Smoke Test the Endpoint
 
 The Rocketship health endpoint answers gRPC, so an HTTPS request returns `415` with `application/grpc`, which confirms end-to-end TLS:
 
 ```bash
-curl -v https://globalbank.rocketship.sh/healthz
+curl -v https://cli.globalbank.rocketship.sh/healthz
 ```
 
 Output snippet:
@@ -300,7 +286,7 @@ Output snippet:
 Create and use a profile from the CLI:
 
 ```bash
-rocketship profile create globalbank grpcs://globalbank.rocketship.sh
+rocketship profile create globalbank grpcs://cli.globalbank.rocketship.sh
 rocketship profile use globalbank
 rocketship list    # Should connect through TLS without --engine
 ```

--- a/docs/src/deploy/digitalocean.md
+++ b/docs/src/deploy/digitalocean.md
@@ -67,10 +67,10 @@ Issue a SAN certificate that covers `cli.rocketship.globalbank.com`, `app.rocket
 
 ```bash
 # optional: remove the old secret if it exists
-kubectl delete secret rocketship-cloud-tls -n rocketship 2>/dev/null || true
+kubectl delete secret globalbank-tls -n rocketship 2>/dev/null || true
 
 # create the secret with the new cert/key
-kubectl create secret tls rocketship-cloud-tls \
+kubectl create secret tls globalbank-tls \
   --namespace rocketship \
   --cert=/etc/letsencrypt/live/rocketship.sh/fullchain.pem \
   --key=/etc/letsencrypt/live/rocketship.sh/privkey.pem
@@ -138,7 +138,7 @@ helm install rocketship charts/rocketship \
   --set ingress.annotations."nginx\.ingress\.kubernetes\.io/backend-protocol"=GRPC \
   --set ingress.annotations."nginx\.ingress\.kubernetes\.io/ssl-redirect"="true" \
   --set ingress.annotations."nginx\.ingress\.kubernetes\.io/proxy-body-size"="0" \
-  --set ingress.tls[0].secretName=rocketship-cloud-tls \
+  --set ingress.tls[0].secretName=globalbank-tls \
   --set ingress.tls[0].hosts[0]=cli.rocketship.globalbank.com \
   --set ingress.hosts[0].host=cli.rocketship.globalbank.com \
   --set ingress.hosts[0].paths[0].path=/ \
@@ -172,7 +172,7 @@ PY
      --from-literal=cookieSecret="$COOKIE_SECRET"
    ```
 
-2. **Review `charts/rocketship/values-oidc-web.yaml`:** the preset already targets GitHub, sets the redirect URL to `https://app.rocketship.globalbank.com/oauth2/callback`, and reuses `rocketship-cloud-tls`. Adjust only if you are customising domains.
+2. **Review `charts/rocketship/values-oidc-web.yaml`:** the preset already targets GitHub, sets the redirect URL to `https://app.rocketship.globalbank.com/oauth2/callback`, and reuses `globalbank-tls`. Adjust only if you are customising domains.
 
 3. **Apply the preset alongside the existing gRPC values:**
    ```bash
@@ -192,7 +192,7 @@ GlobalBank’s GitHub auth broker mints Rocketship-signed JWTs so every develope
 1. **Create the signing key secret.** Generate a 2048-bit RSA key (or reuse an existing one) and store it as `signing-key.pem`.
    ```bash
    openssl genrsa -out signing-key.pem 2048
-   kubectl create secret generic rocketship-auth-broker-signing \
+   kubectl create secret generic globalbank-auth-broker-signing \
      --namespace rocketship \
      --from-file=signing-key.pem
    ```
@@ -200,7 +200,7 @@ GlobalBank’s GitHub auth broker mints Rocketship-signed JWTs so every develope
 2. **Provision an encryption key for the refresh-token store.**
    ```bash
    python -c "import os,base64;print(base64.b64encode(os.urandom(32)).decode())" > broker-store.key
-   kubectl create secret generic rocketship-auth-broker-store \
+   kubectl create secret generic globalbank-auth-broker-store \
      --namespace rocketship \
      --from-file=ROCKETSHIP_BROKER_STORE_KEY=broker-store.key
    ```
@@ -213,7 +213,7 @@ GlobalBank’s GitHub auth broker mints Rocketship-signed JWTs so every develope
 
 4. **Store the GitHub client secret.**
    ```bash
-   kubectl create secret generic rocketship-github-oauth \
+   kubectl create secret generic globalbank-github-oauth \
      --namespace rocketship \
      --from-literal=ROCKETSHIP_GITHUB_CLIENT_SECRET=<github-client-secret>
    ```
@@ -224,7 +224,7 @@ GlobalBank’s GitHub auth broker mints Rocketship-signed JWTs so every develope
    helm upgrade --install rocketship charts/rocketship \
      --namespace rocketship \
      -f charts/rocketship/values-production.yaml \
-     -f charts/rocketship/values-github-cloud.yaml \
+     -f charts/rocketship/values-github-globalbank.yaml \
      --set engine.image.repository=$REGISTRY/rocketship-engine \
      --set engine.image.tag=$TAG \
      --set worker.image.repository=$REGISTRY/rocketship-worker \

--- a/docs/src/reference/rocketship_profile_create.md
+++ b/docs/src/reference/rocketship_profile_create.md
@@ -8,7 +8,7 @@ Create a new connection profile for a Rocketship deployment.
 
 The URL should be the base URL of your Rocketship deployment, e.g.:
   https://rocketship.company.com
-  https://globalbank.rocketship.sh
+  https://cli.rocketship.globalbank.com
 
 TLS settings will be automatically detected from the URL scheme.
 

--- a/internal/authbroker/config.go
+++ b/internal/authbroker/config.go
@@ -1,0 +1,180 @@
+package authbroker
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	ListenAddr      string
+	Issuer          string
+	Audience        string
+	ClientID        string
+	SigningKeyPath  string
+	SigningKeyID    string
+	AccessTokenTTL  time.Duration
+	RefreshTokenTTL time.Duration
+	Scopes          []string
+	GitHub          GitHubConfig
+	Store           StoreConfig
+}
+
+type GitHubConfig struct {
+	ClientID     string
+	ClientSecret string
+	DeviceURL    string
+	TokenURL     string
+	UserURL      string
+	EmailsURL    string
+	Scopes       []string
+}
+
+type StoreConfig struct {
+	Path          string
+	EncryptionKey []byte
+}
+
+const (
+	defaultListenAddr    = ":8080"
+	defaultAccessTTL     = time.Hour
+	defaultRefreshTTL    = 30 * 24 * time.Hour
+	defaultGitHubDevice  = "https://github.com/login/device/code"
+	defaultGitHubToken   = "https://github.com/login/oauth/access_token"
+	defaultGitHubUser    = "https://api.github.com/user"
+	defaultGitHubEmails  = "https://api.github.com/user/emails"
+	defaultStoreFilename = "rocketship-auth-broker.enc"
+)
+
+func LoadConfigFromEnv() (Config, error) {
+	cfg := Config{
+		ListenAddr:      getEnvDefault("ROCKETSHIP_BROKER_LISTEN_ADDR", defaultListenAddr),
+		Issuer:          strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_ISSUER")),
+		Audience:        strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_AUDIENCE")),
+		ClientID:        strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_CLIENT_ID")),
+		SigningKeyPath:  strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_SIGNING_KEY_FILE")),
+		SigningKeyID:    strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_SIGNING_KEY_ID")),
+		AccessTokenTTL:  defaultAccessTTL,
+		RefreshTokenTTL: defaultRefreshTTL,
+		GitHub: GitHubConfig{
+			ClientID:     strings.TrimSpace(os.Getenv("ROCKETSHIP_GITHUB_CLIENT_ID")),
+			ClientSecret: strings.TrimSpace(os.Getenv("ROCKETSHIP_GITHUB_CLIENT_SECRET")),
+			DeviceURL:    getEnvDefault("ROCKETSHIP_GITHUB_DEVICE_URL", defaultGitHubDevice),
+			TokenURL:     getEnvDefault("ROCKETSHIP_GITHUB_TOKEN_URL", defaultGitHubToken),
+			UserURL:      getEnvDefault("ROCKETSHIP_GITHUB_USER_URL", defaultGitHubUser),
+			EmailsURL:    getEnvDefault("ROCKETSHIP_GITHUB_EMAILS_URL", defaultGitHubEmails),
+		},
+		Store: StoreConfig{
+			Path: getEnvDefault("ROCKETSHIP_BROKER_STORE_PATH", defaultStorePath()),
+		},
+	}
+
+	if ttlStr := strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_ACCESS_TTL")); ttlStr != "" {
+		ttl, err := time.ParseDuration(ttlStr)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid ROCKETSHIP_BROKER_ACCESS_TTL: %w", err)
+		}
+		if ttl <= 0 {
+			return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_ACCESS_TTL must be positive")
+		}
+		cfg.AccessTokenTTL = ttl
+	}
+
+	if ttlStr := strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_REFRESH_TTL")); ttlStr != "" {
+		ttl, err := time.ParseDuration(ttlStr)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid ROCKETSHIP_BROKER_REFRESH_TTL: %w", err)
+		}
+		if ttl <= 0 {
+			return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_REFRESH_TTL must be positive")
+		}
+		cfg.RefreshTokenTTL = ttl
+	}
+
+	cfg.Scopes = defaultScopes(os.Getenv("ROCKETSHIP_BROKER_SCOPES"))
+	cfg.GitHub.Scopes = defaultGitHubScopes(os.Getenv("ROCKETSHIP_GITHUB_SCOPES"))
+
+	if key := strings.TrimSpace(os.Getenv("ROCKETSHIP_BROKER_STORE_KEY")); key != "" {
+		decoded, err := base64.StdEncoding.DecodeString(key)
+		if err != nil {
+			return Config{}, fmt.Errorf("failed to decode ROCKETSHIP_BROKER_STORE_KEY: %w", err)
+		}
+		if len(decoded) != 32 {
+			return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_STORE_KEY must decode to 32 bytes")
+		}
+		cfg.Store.EncryptionKey = decoded
+	}
+
+	if cfg.Issuer == "" {
+		return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_ISSUER is required")
+	}
+	if cfg.Audience == "" {
+		return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_AUDIENCE is required")
+	}
+	if cfg.ClientID == "" {
+		return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_CLIENT_ID is required")
+	}
+	if cfg.SigningKeyPath == "" {
+		return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_SIGNING_KEY_FILE is required")
+	}
+	if cfg.GitHub.ClientID == "" {
+		return Config{}, fmt.Errorf("ROCKETSHIP_GITHUB_CLIENT_ID is required")
+	}
+	if cfg.GitHub.ClientSecret == "" {
+		return Config{}, fmt.Errorf("ROCKETSHIP_GITHUB_CLIENT_SECRET is required")
+	}
+	if len(cfg.Store.EncryptionKey) == 0 {
+		return Config{}, fmt.Errorf("ROCKETSHIP_BROKER_STORE_KEY is required")
+	}
+
+	return cfg, nil
+}
+
+func getEnvDefault(key, def string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		trimmed := strings.TrimSpace(val)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return def
+}
+
+func defaultStorePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return defaultStoreFilename
+	}
+	return filepath.Join(home, ".rocketship", defaultStoreFilename)
+}
+
+func defaultScopes(input string) []string {
+	scopes := strings.TrimSpace(input)
+	if scopes == "" {
+		return []string{"openid", "profile", "email", "offline_access"}
+	}
+	return splitScopes(scopes)
+}
+
+func defaultGitHubScopes(input string) []string {
+	scopes := strings.TrimSpace(input)
+	if scopes == "" {
+		return []string{"read:user", "user:email"}
+	}
+	return splitScopes(scopes)
+}
+
+func splitScopes(scopes string) []string {
+	fields := strings.Fields(scopes)
+	result := make([]string, 0, len(fields))
+	for _, s := range fields {
+		trimmed := strings.TrimSpace(s)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/internal/authbroker/github.go
+++ b/internal/authbroker/github.go
@@ -1,0 +1,214 @@
+package authbroker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const defaultHTTPTimeout = 15 * time.Second
+
+type GitHubClient struct {
+	cfg    GitHubConfig
+	client *http.Client
+}
+
+type DeviceCodeResponse struct {
+	DeviceCode              string        `json:"device_code"`
+	UserCode                string        `json:"user_code"`
+	VerificationURI         string        `json:"verification_uri"`
+	VerificationURIComplete string        `json:"verification_uri_complete"`
+	ExpiresIn               time.Duration `json:"-"`
+	Interval                time.Duration `json:"-"`
+	RawExpiresIn            int           `json:"expires_in"`
+	RawInterval             int           `json:"interval"`
+}
+
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+type tokenError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+type GitHubUser struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+type githubEmail struct {
+	Email    string `json:"email"`
+	Primary  bool   `json:"primary"`
+	Verified bool   `json:"verified"`
+}
+
+func NewGitHubClient(cfg GitHubConfig, client *http.Client) *GitHubClient {
+	if client == nil {
+		client = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &GitHubClient{cfg: cfg, client: client}
+}
+
+func (g *GitHubClient) RequestDeviceCode(ctx context.Context, scopes []string) (DeviceCodeResponse, error) {
+	form := url.Values{}
+	form.Set("client_id", g.cfg.ClientID)
+	if len(scopes) > 0 {
+		form.Set("scope", strings.Join(scopes, " "))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.cfg.DeviceURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return DeviceCodeResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return DeviceCodeResponse{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		snippet := strings.TrimSpace(string(body))
+		if snippet == "" {
+			snippet = resp.Status
+		}
+		return DeviceCodeResponse{}, fmt.Errorf("github device code request failed: %s", snippet)
+	}
+
+	var dc DeviceCodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dc); err != nil {
+		return DeviceCodeResponse{}, err
+	}
+	if dc.RawExpiresIn <= 0 {
+		dc.RawExpiresIn = 900
+	}
+	if dc.RawInterval <= 0 {
+		dc.RawInterval = 5
+	}
+	dc.ExpiresIn = time.Duration(dc.RawExpiresIn) * time.Second
+	dc.Interval = time.Duration(dc.RawInterval) * time.Second
+	return dc, nil
+}
+
+func (g *GitHubClient) ExchangeDeviceCode(ctx context.Context, deviceCode string) (TokenResponse, tokenError, error) {
+	form := url.Values{}
+	form.Set("client_id", g.cfg.ClientID)
+	form.Set("device_code", deviceCode)
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	form.Set("client_secret", g.cfg.ClientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return TokenResponse{}, tokenError{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return TokenResponse{}, tokenError{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		var token TokenResponse
+		if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+			return TokenResponse{}, tokenError{}, err
+		}
+		return token, tokenError{}, nil
+	}
+
+	var terr tokenError
+	if err := json.NewDecoder(resp.Body).Decode(&terr); err != nil {
+		body, _ := io.ReadAll(resp.Body)
+		return TokenResponse{}, tokenError{}, fmt.Errorf("github token exchange failed: %s", strings.TrimSpace(string(body)))
+	}
+	return TokenResponse{}, terr, nil
+}
+
+func (g *GitHubClient) FetchUser(ctx context.Context, accessToken string) (GitHubUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.cfg.UserURL, nil)
+	if err != nil {
+		return GitHubUser{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return GitHubUser{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return GitHubUser{}, fmt.Errorf("github user request failed: %s", strings.TrimSpace(string(body)))
+	}
+
+	var user GitHubUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return GitHubUser{}, err
+	}
+
+	if user.Email == "" {
+		email, err := g.fetchPrimaryEmail(ctx, accessToken)
+		if err == nil {
+			user.Email = email
+		}
+	}
+
+	return user, nil
+}
+
+func (g *GitHubClient) fetchPrimaryEmail(ctx context.Context, accessToken string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.cfg.EmailsURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("failed to fetch primary email")
+	}
+
+	var emails []githubEmail
+	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+		return "", err
+	}
+	for _, e := range emails {
+		if e.Primary && e.Verified && e.Email != "" {
+			return e.Email, nil
+		}
+	}
+	for _, e := range emails {
+		if e.Verified && e.Email != "" {
+			return e.Email, nil
+		}
+	}
+	if len(emails) > 0 {
+		return emails[0].Email, nil
+	}
+	return "", errors.New("no email returned by GitHub")
+}

--- a/internal/authbroker/jwt.go
+++ b/internal/authbroker/jwt.go
@@ -1,0 +1,199 @@
+package authbroker
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type Signer struct {
+	method jwt.SigningMethod
+	rsaKey *rsa.PrivateKey
+	ecKey  *ecdsa.PrivateKey
+	keyID  string
+}
+
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+type JWK struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid,omitempty"`
+	Alg string `json:"alg,omitempty"`
+	Use string `json:"use,omitempty"`
+	N   string `json:"n,omitempty"`
+	E   string `json:"e,omitempty"`
+	X   string `json:"x,omitempty"`
+	Y   string `json:"y,omitempty"`
+	Crv string `json:"crv,omitempty"`
+}
+
+func NewSignerFromPEM(path, keyID string) (*Signer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read signing key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("failed to decode PEM block")
+	}
+
+	// Try PKCS8 first, then specific formats.
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err == nil {
+		return buildSigner(key, keyID)
+	}
+
+	if rsaKey, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return buildSigner(rsaKey, keyID)
+	}
+	if ecKey, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return buildSigner(ecKey, keyID)
+	}
+
+	return nil, errors.New("unsupported signing key format")
+}
+
+func buildSigner(key interface{}, keyID string) (*Signer, error) {
+	signer := &Signer{keyID: keyID}
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		signer.method = jwt.SigningMethodRS256
+		signer.rsaKey = k
+		if signer.keyID == "" {
+			signer.keyID = fmt.Sprintf("rsa-%d", k.N.BitLen())
+		}
+	case *ecdsa.PrivateKey:
+		curveName := curveName(k.Curve)
+		if curveName == "" {
+			return nil, errors.New("unsupported elliptic curve")
+		}
+		switch curveName {
+		case "P-256":
+			signer.method = jwt.SigningMethodES256
+		case "P-384":
+			signer.method = jwt.SigningMethodES384
+		case "P-521":
+			signer.method = jwt.SigningMethodES512
+		default:
+			return nil, errors.New("unsupported ECDSA curve")
+		}
+		signer.ecKey = k
+		if signer.keyID == "" {
+			signer.keyID = fmt.Sprintf("ec-%s", strings.ToLower(curveName))
+		}
+	default:
+		return nil, errors.New("unsupported signing key type")
+	}
+	return signer, nil
+}
+
+func (s *Signer) Sign(claims jwt.MapClaims) (string, error) {
+	if claims == nil {
+		claims = jwt.MapClaims{}
+	}
+	now := time.Now().Unix()
+	if _, ok := claims["iat"]; !ok {
+		claims["iat"] = now
+	}
+	token := jwt.NewWithClaims(s.method, claims)
+	if s.keyID != "" {
+		token.Header["kid"] = s.keyID
+	}
+
+	var signed string
+	var err error
+	if s.rsaKey != nil {
+		signed, err = token.SignedString(s.rsaKey)
+	} else if s.ecKey != nil {
+		signed, err = token.SignedString(s.ecKey)
+	} else {
+		return "", errors.New("no signing key configured")
+	}
+	if err != nil {
+		return "", err
+	}
+	return signed, nil
+}
+
+func (s *Signer) JWKS() (JWKS, error) {
+	switch {
+	case s.rsaKey != nil:
+		return JWKS{Keys: []JWK{rsaPublicJWK(&s.rsaKey.PublicKey, s.keyID)}}, nil
+	case s.ecKey != nil:
+		return JWKS{Keys: []JWK{ecPublicJWK(&s.ecKey.PublicKey, s.keyID)}}, nil
+	default:
+		return JWKS{}, errors.New("no signing key configured")
+	}
+}
+
+func (j JWKS) JSON() ([]byte, error) {
+	return json.Marshal(j)
+}
+
+func rsaPublicJWK(pub *rsa.PublicKey, kid string) JWK {
+	return JWK{
+		Kty: "RSA",
+		Kid: kid,
+		Use: "sig",
+		Alg: "RS256",
+		N:   encodeBig(pub.N),
+		E:   encodeBig(big.NewInt(int64(pub.E))),
+	}
+}
+
+func ecPublicJWK(pub *ecdsa.PublicKey, kid string) JWK {
+	curve := curveName(pub.Curve)
+	return JWK{
+		Kty: "EC",
+		Kid: kid,
+		Use: "sig",
+		Alg: ecAlg(curve),
+		Crv: curve,
+		X:   encodeBig(pub.X),
+		Y:   encodeBig(pub.Y),
+	}
+}
+
+func encodeBig(i *big.Int) string {
+	return base64.RawURLEncoding.EncodeToString(i.Bytes())
+}
+
+func curveName(curve elliptic.Curve) string {
+	switch curve {
+	case elliptic.P256():
+		return "P-256"
+	case elliptic.P384():
+		return "P-384"
+	case elliptic.P521():
+		return "P-521"
+	default:
+		return ""
+	}
+}
+
+func ecAlg(curve string) string {
+	switch curve {
+	case "P-256":
+		return "ES256"
+	case "P-384":
+		return "ES384"
+	case "P-521":
+		return "ES512"
+	default:
+		return "ES256"
+	}
+}

--- a/internal/authbroker/server.go
+++ b/internal/authbroker/server.go
@@ -1,0 +1,431 @@
+package authbroker
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rocketship-ai/rocketship/internal/authbroker/store"
+)
+
+// Server exposes OAuth-compatible endpoints backed by GitHub device flow.
+type Server struct {
+	cfg     Config
+	signer  *Signer
+	github  githubProvider
+	store   store.Store
+	mux     *http.ServeMux
+	pending map[string]deviceSession
+	mu      sync.Mutex
+}
+
+type githubProvider interface {
+	RequestDeviceCode(ctx context.Context, scopes []string) (DeviceCodeResponse, error)
+	ExchangeDeviceCode(ctx context.Context, deviceCode string) (TokenResponse, tokenError, error)
+	FetchUser(ctx context.Context, accessToken string) (GitHubUser, error)
+}
+
+type deviceSession struct {
+	clientID  string
+	scopes    []string
+	expiresAt time.Time
+}
+
+// NewServer constructs a broker server using the provided configuration.
+func NewServer(cfg Config) (*Server, error) {
+	signer, err := NewSignerFromPEM(cfg.SigningKeyPath, cfg.SigningKeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenStore, err := store.NewFileStore(cfg.Store.Path, cfg.Store.EncryptionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return newServerWithComponents(cfg, signer, NewGitHubClient(cfg.GitHub, nil), tokenStore)
+}
+
+func newServerWithComponents(cfg Config, signer *Signer, github githubProvider, tokenStore store.Store) (*Server, error) {
+	if signer == nil {
+		return nil, fmt.Errorf("signer is required")
+	}
+	if github == nil {
+		return nil, fmt.Errorf("github client is required")
+	}
+	if tokenStore == nil {
+		return nil, fmt.Errorf("token store is required")
+	}
+
+	srv := &Server{
+		cfg:     cfg,
+		signer:  signer,
+		github:  github,
+		store:   tokenStore,
+		mux:     http.NewServeMux(),
+		pending: make(map[string]deviceSession),
+	}
+	srv.routes()
+	return srv, nil
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("/device/code", s.handleDeviceCode)
+	s.mux.HandleFunc("/token", s.handleToken)
+	s.mux.HandleFunc("/refresh", s.handleRefreshEndpoint)
+	s.mux.HandleFunc("/.well-known/jwks.json", s.handleJWKS)
+	s.mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+}
+
+// ServeHTTP satisfies http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid form payload")
+		return
+	}
+
+	clientID := strings.TrimSpace(r.Form.Get("client_id"))
+	if clientID == "" {
+		writeOAuthError(w, "invalid_request", "client_id missing")
+		return
+	}
+	if !strings.EqualFold(clientID, s.cfg.ClientID) {
+		writeOAuthError(w, "unauthorized_client", "client_id not recognised")
+		return
+	}
+
+	ctx := r.Context()
+	dc, err := s.github.RequestDeviceCode(ctx, s.cfg.GitHub.Scopes)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("github device flow error: %v", err))
+		return
+	}
+
+	s.mu.Lock()
+	s.pending[dc.DeviceCode] = deviceSession{
+		clientID:  clientID,
+		scopes:    copyScopes(s.cfg.Scopes),
+		expiresAt: time.Now().Add(dc.ExpiresIn),
+	}
+	s.mu.Unlock()
+
+	resp := map[string]interface{}{
+		"device_code":               dc.DeviceCode,
+		"user_code":                 dc.UserCode,
+		"verification_uri":          dc.VerificationURI,
+		"verification_uri_complete": dc.VerificationURIComplete,
+		"expires_in":                dc.RawExpiresIn,
+		"interval":                  dc.RawInterval,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid form payload")
+		return
+	}
+
+	grantType := strings.TrimSpace(r.Form.Get("grant_type"))
+	switch grantType {
+	case "urn:ietf:params:oauth:grant-type:device_code":
+		s.handleDeviceGrant(w, r)
+	case "refresh_token":
+		s.handleRefreshGrant(w, r)
+	default:
+		writeOAuthError(w, "unsupported_grant_type", "grant_type not supported")
+	}
+}
+
+func (s *Server) handleRefreshEndpoint(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid form payload")
+		return
+	}
+	r.Form.Set("grant_type", "refresh_token")
+	s.handleRefreshGrant(w, r)
+}
+
+func (s *Server) handleDeviceGrant(w http.ResponseWriter, r *http.Request) {
+	deviceCode := strings.TrimSpace(r.Form.Get("device_code"))
+	clientID := strings.TrimSpace(r.Form.Get("client_id"))
+	if deviceCode == "" {
+		writeOAuthError(w, "invalid_request", "device_code missing")
+		return
+	}
+	if !strings.EqualFold(clientID, s.cfg.ClientID) {
+		writeOAuthError(w, "unauthorized_client", "client_id not recognised")
+		return
+	}
+
+	session, ok := s.lookupDeviceSession(deviceCode)
+	if !ok {
+		writeOAuthError(w, "authorization_pending", "device authorization pending")
+		return
+	}
+
+	ctx := r.Context()
+	token, terr, err := s.github.ExchangeDeviceCode(ctx, deviceCode)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("github token exchange failed: %v", err))
+		return
+	}
+	if terr.Error != "" {
+		writeOAuthError(w, terr.Error, terr.ErrorDescription)
+		return
+	}
+
+	user, err := s.github.FetchUser(ctx, token.AccessToken)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("github user lookup failed: %v", err))
+		return
+	}
+
+	if user.Email == "" {
+		writeOAuthError(w, "access_denied", "github account is missing an email address")
+		return
+	}
+
+	now := time.Now()
+	accessExpires := now.Add(s.cfg.AccessTokenTTL)
+	refreshExpires := now.Add(s.cfg.RefreshTokenTTL)
+
+	claims := jwt.MapClaims{
+		"iss":                s.cfg.Issuer,
+		"aud":                s.cfg.Audience,
+		"sub":                fmt.Sprintf("github:%d", user.ID),
+		"exp":                accessExpires.Unix(),
+		"iat":                now.Unix(),
+		"email":              user.Email,
+		"email_verified":     true,
+		"name":               user.Name,
+		"preferred_username": user.Login,
+		"scope":              strings.Join(session.scopes, " "),
+		"roles":              []string{"owner"},
+	}
+	jti, err := generateRandomToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to mint token identifier")
+		return
+	}
+	claims["jti"] = jti
+
+	signed, err := s.signer.Sign(claims)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to sign token")
+		return
+	}
+
+	refreshToken, err := generateRandomToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to mint refresh token")
+		return
+	}
+
+	record := store.RefreshRecord{
+		Subject:   claims["sub"].(string),
+		Email:     user.Email,
+		Name:      user.Name,
+		Username:  user.Login,
+		Roles:     []string{"owner"},
+		Scopes:    session.scopes,
+		IssuedAt:  now,
+		ExpiresAt: refreshExpires,
+	}
+
+	if err := s.store.Save(refreshToken, record); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist refresh token")
+		return
+	}
+
+	s.removeDeviceSession(deviceCode)
+
+	payload := oauthTokenResponse{
+		AccessToken:  signed,
+		TokenType:    "Bearer",
+		ExpiresIn:    int(s.cfg.AccessTokenTTL.Seconds()),
+		RefreshToken: refreshToken,
+		Scope:        strings.Join(session.scopes, " "),
+		IDToken:      signed,
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) handleRefreshGrant(w http.ResponseWriter, r *http.Request) {
+	refreshToken := strings.TrimSpace(r.Form.Get("refresh_token"))
+	clientID := strings.TrimSpace(r.Form.Get("client_id"))
+	if refreshToken == "" {
+		writeOAuthError(w, "invalid_request", "refresh_token missing")
+		return
+	}
+	if clientID != "" && !strings.EqualFold(clientID, s.cfg.ClientID) {
+		writeOAuthError(w, "unauthorized_client", "client_id not recognised")
+		return
+	}
+
+	record, err := s.store.Get(refreshToken)
+	if err != nil {
+		writeOAuthError(w, "invalid_grant", "refresh token invalid or expired")
+		return
+	}
+	if time.Now().After(record.ExpiresAt) {
+		_ = s.store.Delete(refreshToken)
+		writeOAuthError(w, "invalid_grant", "refresh token expired")
+		return
+	}
+
+	now := time.Now()
+	accessExpires := now.Add(s.cfg.AccessTokenTTL)
+
+	claims := jwt.MapClaims{
+		"iss":                s.cfg.Issuer,
+		"aud":                s.cfg.Audience,
+		"sub":                record.Subject,
+		"exp":                accessExpires.Unix(),
+		"iat":                now.Unix(),
+		"email":              record.Email,
+		"email_verified":     true,
+		"name":               record.Name,
+		"preferred_username": record.Username,
+		"scope":              strings.Join(record.Scopes, " "),
+		"roles":              record.Roles,
+	}
+	jti, err := generateRandomToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to mint token identifier")
+		return
+	}
+	claims["jti"] = jti
+
+	signed, err := s.signer.Sign(claims)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to sign token")
+		return
+	}
+
+	newRefresh, err := generateRandomToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to mint refresh token")
+		return
+	}
+
+	record.IssuedAt = now
+	record.ExpiresAt = now.Add(s.cfg.RefreshTokenTTL)
+	if err := s.store.Delete(refreshToken); err != nil {
+		writeOAuthError(w, "invalid_grant", "refresh token invalid")
+		return
+	}
+	if err := s.store.Save(newRefresh, record); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist refresh token")
+		return
+	}
+
+	payload := oauthTokenResponse{
+		AccessToken:  signed,
+		TokenType:    "Bearer",
+		ExpiresIn:    int(s.cfg.AccessTokenTTL.Seconds()),
+		RefreshToken: newRefresh,
+		Scope:        strings.Join(record.Scopes, " "),
+		IDToken:      signed,
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	jwks, err := s.signer.JWKS()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to produce JWKS")
+		return
+	}
+	writeJSON(w, http.StatusOK, jwks)
+}
+
+func (s *Server) lookupDeviceSession(deviceCode string) (deviceSession, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	session, ok := s.pending[deviceCode]
+	if !ok {
+		return deviceSession{}, false
+	}
+	if time.Now().After(session.expiresAt) {
+		delete(s.pending, deviceCode)
+		return deviceSession{}, false
+	}
+	return session, true
+}
+
+func (s *Server) removeDeviceSession(deviceCode string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.pending, deviceCode)
+}
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeOAuthError(w http.ResponseWriter, code, description string) {
+	payload := map[string]string{"error": code}
+	if description != "" {
+		payload["error_description"] = description
+	}
+	writeJSON(w, http.StatusBadRequest, payload)
+}
+
+func copyScopes(scopes []string) []string {
+	if len(scopes) == 0 {
+		return nil
+	}
+	c := make([]string, len(scopes))
+	copy(c, scopes)
+	return c
+}
+
+func generateRandomToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/internal/authbroker/server_test.go
+++ b/internal/authbroker/server_test.go
@@ -1,0 +1,288 @@
+package authbroker
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rocketship-ai/rocketship/internal/authbroker/store"
+)
+
+type fakeGitHub struct {
+	deviceResp DeviceCodeResponse
+	tokenResp  TokenResponse
+	tokenErr   tokenError
+	user       GitHubUser
+
+	mu          sync.Mutex
+	deviceCalls int
+	tokenCalls  int
+}
+
+func (f *fakeGitHub) RequestDeviceCode(_ context.Context, _ []string) (DeviceCodeResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deviceCalls++
+	return f.deviceResp, nil
+}
+
+func (f *fakeGitHub) ExchangeDeviceCode(_ context.Context, _ string) (TokenResponse, tokenError, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tokenCalls++
+	return f.tokenResp, f.tokenErr, nil
+}
+
+func (f *fakeGitHub) FetchUser(_ context.Context, _ string) (GitHubUser, error) {
+	return f.user, nil
+}
+
+type memoryStore struct {
+	mu   sync.Mutex
+	data map[string]store.RefreshRecord
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{data: make(map[string]store.RefreshRecord)}
+}
+
+func (m *memoryStore) Save(token string, record store.RefreshRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[token] = record
+	return nil
+}
+
+func (m *memoryStore) Get(token string) (store.RefreshRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rec, ok := m.data[token]
+	if !ok {
+		return store.RefreshRecord{}, store.ErrNotFound
+	}
+	return rec, nil
+}
+
+func (m *memoryStore) Delete(token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.data[token]; !ok {
+		return store.ErrNotFound
+	}
+	delete(m.data, token)
+	return nil
+}
+
+func TestServerDeviceFlowAndRefresh(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	signer, err := buildSigner(key, "test-key")
+	if err != nil {
+		t.Fatalf("failed to build signer: %v", err)
+	}
+
+	cfg := Config{
+		Issuer:          "https://cli.test",
+		Audience:        "rocketship-cli",
+		ClientID:        "rocketship-cli",
+		AccessTokenTTL:  time.Minute,
+		RefreshTokenTTL: time.Hour,
+		Scopes:          []string{"openid", "profile", "email"},
+		GitHub: GitHubConfig{
+			ClientID:     "gh-client",
+			ClientSecret: "gh-secret",
+			Scopes:       []string{"read:user"},
+		},
+	}
+
+	fake := &fakeGitHub{
+		deviceResp: DeviceCodeResponse{
+			DeviceCode:              "device-123",
+			UserCode:                "code-456",
+			VerificationURI:         "https://github.com/login/device",
+			VerificationURIComplete: "https://github.com/login/device?user_code=code-456",
+			RawExpiresIn:            600,
+			RawInterval:             5,
+			ExpiresIn:               10 * time.Minute,
+			Interval:                5 * time.Second,
+		},
+		tokenResp: TokenResponse{
+			AccessToken: "gh-access",
+			TokenType:   "bearer",
+			Scope:       "read:user",
+		},
+		user: GitHubUser{
+			ID:    1234,
+			Login: "octo",
+			Name:  "Octo Cat",
+			Email: "octo@example.com",
+		},
+	}
+
+	memStore := newMemoryStore()
+
+	srv, err := newServerWithComponents(cfg, signer, fake, memStore)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/device/code", strings.NewReader(url.Values{
+		"client_id": {cfg.ClientID},
+	}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	srv.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("device code request failed: %d", recorder.Code)
+	}
+	var dcResp struct {
+		DeviceCode string `json:"device_code"`
+		UserCode   string `json:"user_code"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &dcResp); err != nil {
+		t.Fatalf("failed to parse device response: %v", err)
+	}
+	if dcResp.DeviceCode != "device-123" {
+		t.Fatalf("unexpected device code: %s", dcResp.DeviceCode)
+	}
+
+	tokenReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(url.Values{
+		"client_id":   {cfg.ClientID},
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		"device_code": {dcResp.DeviceCode},
+	}.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenRec := httptest.NewRecorder()
+	srv.ServeHTTP(tokenRec, tokenReq)
+
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token exchange failed: %d", tokenRec.Code)
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		TokenType    string `json:"token_type"`
+	}
+	if err := json.Unmarshal(tokenRec.Body.Bytes(), &tokenResp); err != nil {
+		t.Fatalf("failed to parse token response: %v", err)
+	}
+	if tokenResp.AccessToken == "" || tokenResp.RefreshToken == "" {
+		t.Fatalf("expected access and refresh tokens in response")
+	}
+	if tokenResp.TokenType != "Bearer" {
+		t.Fatalf("unexpected token type: %s", tokenResp.TokenType)
+	}
+
+	claims := jwt.MapClaims{}
+	if _, err := jwt.ParseWithClaims(tokenResp.AccessToken, claims, func(token *jwt.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	}); err != nil {
+		t.Fatalf("issued token failed validation: %v", err)
+	}
+
+	refreshReq := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tokenResp.RefreshToken},
+	}.Encode()))
+	refreshReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	refreshRec := httptest.NewRecorder()
+	srv.ServeHTTP(refreshRec, refreshReq)
+	if refreshRec.Code != http.StatusOK {
+		t.Fatalf("refresh grant failed: %d", refreshRec.Code)
+	}
+
+	var refreshResp struct {
+		RefreshToken string `json:"refresh_token"`
+		AccessToken  string `json:"access_token"`
+	}
+	if err := json.Unmarshal(refreshRec.Body.Bytes(), &refreshResp); err != nil {
+		t.Fatalf("failed to parse refresh response: %v", err)
+	}
+	if refreshResp.RefreshToken == tokenResp.RefreshToken {
+		t.Fatalf("expected refresh token rotation")
+	}
+	if refreshResp.AccessToken == tokenResp.AccessToken {
+		t.Fatalf("expected new access token")
+	}
+}
+
+func TestServerRejectsUnknownClient(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	signer, err := buildSigner(key, "test-key")
+	if err != nil {
+		t.Fatalf("failed to build signer: %v", err)
+	}
+
+	cfg := Config{
+		Issuer:          "https://cli.test",
+		Audience:        "rocketship-cli",
+		ClientID:        "rocketship-cli",
+		AccessTokenTTL:  time.Minute,
+		RefreshTokenTTL: time.Hour,
+		Scopes:          []string{"openid"},
+		GitHub:          GitHubConfig{ClientID: "gh", ClientSecret: "secret"},
+	}
+
+	fake := &fakeGitHub{deviceResp: DeviceCodeResponse{}}
+	srv, err := newServerWithComponents(cfg, signer, fake, newMemoryStore())
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/device/code", strings.NewReader(url.Values{
+		"client_id": {"other-client"},
+	}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected bad request for unknown client, got %d", rec.Code)
+	}
+}
+
+func TestServerJWKS(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	signer, err := buildSigner(key, "test-key")
+	if err != nil {
+		t.Fatalf("failed to build signer: %v", err)
+	}
+
+	cfg := Config{}
+	fake := &fakeGitHub{}
+	srv, err := newServerWithComponents(cfg, signer, fake, newMemoryStore())
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected OK status, got %d", rec.Code)
+	}
+	body := rec.Body.Bytes()
+	if !bytes.Contains(body, []byte("\"keys\"")) {
+		t.Fatalf("jwks response missing keys: %s", string(body))
+	}
+}

--- a/internal/authbroker/store/store.go
+++ b/internal/authbroker/store/store.go
@@ -1,0 +1,207 @@
+package store
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type RefreshRecord struct {
+	Subject   string    `json:"subject"`
+	Email     string    `json:"email"`
+	Name      string    `json:"name"`
+	Username  string    `json:"username"`
+	Roles     []string  `json:"roles"`
+	Scopes    []string  `json:"scopes"`
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type Store interface {
+	Save(token string, record RefreshRecord) error
+	Get(token string) (RefreshRecord, error)
+	Delete(token string) error
+}
+
+var ErrNotFound = errors.New("refresh token not found")
+
+// FileStore persists refresh tokens using AES-GCM encryption.
+type FileStore struct {
+	path string
+	key  []byte
+
+	mu      sync.Mutex
+	records map[string]RefreshRecord
+}
+
+type payload struct {
+	Records map[string]RefreshRecord `json:"records"`
+	SavedAt time.Time                `json:"saved_at"`
+	Version int                      `json:"version"`
+}
+
+const currentVersion = 1
+
+func NewFileStore(path string, key []byte) (*FileStore, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("file store expects 32-byte key")
+	}
+
+	fs := &FileStore{
+		path:    path,
+		key:     append([]byte(nil), key...),
+		records: make(map[string]RefreshRecord),
+	}
+
+	if err := fs.load(); err != nil {
+		return nil, err
+	}
+	return fs, nil
+}
+
+func (f *FileStore) Save(token string, record RefreshRecord) error {
+	hash := hashToken(token)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.records[hash] = record
+	return f.persistLocked()
+}
+
+func (f *FileStore) Get(token string) (RefreshRecord, error) {
+	hash := hashToken(token)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	rec, ok := f.records[hash]
+	if !ok {
+		return RefreshRecord{}, ErrNotFound
+	}
+	return rec, nil
+}
+
+func (f *FileStore) Delete(token string) error {
+	hash := hashToken(token)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if _, ok := f.records[hash]; !ok {
+		return ErrNotFound
+	}
+	delete(f.records, hash)
+	return f.persistLocked()
+}
+
+func (f *FileStore) load() error {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return f.ensureParent()
+		}
+		return fmt.Errorf("failed to read refresh store: %w", err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	plaintext, err := f.decrypt(data)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt refresh store: %w", err)
+	}
+
+	var pl payload
+	if err := json.Unmarshal(plaintext, &pl); err != nil {
+		return fmt.Errorf("failed to decode refresh store: %w", err)
+	}
+
+	if pl.Records != nil {
+		f.records = pl.Records
+	}
+	return nil
+}
+
+func (f *FileStore) persistLocked() error {
+	if err := f.ensureParent(); err != nil {
+		return err
+	}
+
+	pl := payload{
+		Records: f.records,
+		SavedAt: time.Now().UTC(),
+		Version: currentVersion,
+	}
+	buf, err := json.Marshal(pl)
+	if err != nil {
+		return fmt.Errorf("failed to marshal refresh store: %w", err)
+	}
+
+	ciphertext, err := f.encrypt(buf)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt refresh store: %w", err)
+	}
+
+	if err := os.WriteFile(f.path, ciphertext, 0o600); err != nil {
+		return fmt.Errorf("failed to write refresh store: %w", err)
+	}
+	return nil
+}
+
+func (f *FileStore) ensureParent() error {
+	dir := filepath.Dir(f.path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create refresh store directory: %w", err)
+	}
+	return nil
+}
+
+func (f *FileStore) encrypt(plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(f.key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	sealed := gcm.Seal(nil, nonce, plaintext, nil)
+	return append(nonce, sealed...), nil
+}
+
+func (f *FileStore) decrypt(ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(f.key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, errors.New("ciphertext too short")
+	}
+	nonce := ciphertext[:nonceSize]
+	data := ciphertext[nonceSize:]
+	return gcm.Open(nil, nonce, data, nil)
+}
+
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return fmt.Sprintf("%x", sum[:])
+}

--- a/internal/authbroker/store/store_test.go
+++ b/internal/authbroker/store/store_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.enc")
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	fs, err := NewFileStore(path, key)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	record := RefreshRecord{
+		Subject:   "user-123",
+		Email:     "user@example.com",
+		Name:      "User",
+		Username:  "user",
+		Roles:     []string{"owner"},
+		Scopes:    []string{"openid"},
+		IssuedAt:  time.Now().UTC().Truncate(time.Second),
+		ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+	}
+
+	if err := fs.Save("token-1", record); err != nil {
+		t.Fatalf("failed to save record: %v", err)
+	}
+
+	loaded, err := fs.Get("token-1")
+	if err != nil {
+		t.Fatalf("failed to load record: %v", err)
+	}
+	if loaded.Subject != record.Subject || loaded.Email != record.Email {
+		t.Fatalf("loaded record mismatch: %+v", loaded)
+	}
+
+	// Re-open to ensure data persisted and encrypted
+	fs2, err := NewFileStore(path, key)
+	if err != nil {
+		t.Fatalf("failed to reopen store: %v", err)
+	}
+	if _, err := fs2.Get("token-1"); err != nil {
+		t.Fatalf("expected record after reopen: %v", err)
+	}
+
+	if err := fs2.Delete("token-1"); err != nil {
+		t.Fatalf("failed to delete token: %v", err)
+	}
+	if _, err := fs2.Get("token-1"); err == nil {
+		t.Fatalf("expected not found after delete")
+	}
+}
+
+func TestFileStoreRejectsInvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.enc")
+	if _, err := NewFileStore(path, []byte("short")); err == nil {
+		t.Fatalf("expected error for short key")
+	}
+}
+
+func TestEncryptedContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "store.enc")
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	fs, err := NewFileStore(path, key)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	if err := fs.Save("token-1", RefreshRecord{Subject: "s"}); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read ciphertext: %v", err)
+	}
+	if len(contents) == 0 {
+		t.Fatalf("expected encrypted data")
+	}
+
+	// Ensure plaintext token is not present when base64 encoded
+	encoded := base64.StdEncoding.EncodeToString(contents)
+	if strings.Contains(encoded, "token-1") {
+		t.Fatalf("ciphertext should not contain plaintext token")
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -9,7 +9,7 @@ import (
 
 // Config represents the overall CLI configuration
 type Config struct {
-	DefaultProfile string            `json:"default_profile"`
+	DefaultProfile string             `json:"default_profile"`
 	Profiles       map[string]Profile `json:"profiles"`
 }
 
@@ -45,16 +45,16 @@ type TeamContext struct {
 
 // GetDefaultProfile returns the built-in default profile for app.rocketship.sh
 func GetDefaultProfile() Profile {
-    return Profile{
-        Name:          "default",
-        // Default cloud-hosted CLI endpoint
-        EngineAddress: "cli.rocketship.sh:443",
-        TLS: TLSConfig{
-            Enabled: true,
-            Domain:  "cli.rocketship.sh",
-        },
-        Environment: make(map[string]string),
-    }
+	return Profile{
+		Name: "default",
+		// Default cloud-hosted CLI endpoint
+		EngineAddress: "cli.rocketship.sh:443",
+		TLS: TLSConfig{
+			Enabled: true,
+			Domain:  "cli.rocketship.sh",
+		},
+		Environment: make(map[string]string),
+	}
 }
 
 // DefaultConfig returns a new config with sensible defaults
@@ -71,14 +71,14 @@ func ConfigPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	
+
 	configDir := filepath.Join(home, ".rocketship")
-	
+
 	// Ensure config directory exists
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create config directory: %w", err)
 	}
-	
+
 	return filepath.Join(configDir, "config.json"), nil
 }
 
@@ -88,32 +88,32 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// If config file doesn't exist, return default config
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		return DefaultConfig(), nil
 	}
-	
+
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
-	
+
 	var config Config
 	if err := json.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
-	
+
 	// Ensure we have a default profile if none is set
 	if config.DefaultProfile == "" {
 		config.DefaultProfile = "default"
 	}
-	
+
 	// Ensure profiles map exists
 	if config.Profiles == nil {
 		config.Profiles = make(map[string]Profile)
 	}
-	
+
 	return &config, nil
 }
 
@@ -123,16 +123,16 @@ func (c *Config) SaveConfig() error {
 	if err != nil {
 		return err
 	}
-	
+
 	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
-	
+
 	if err := os.WriteFile(configPath, data, 0644); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -141,7 +141,7 @@ func (c *Config) GetProfile(name string) (Profile, bool) {
 	if name == "default" {
 		return GetDefaultProfile(), true
 	}
-	
+
 	profile, exists := c.Profiles[name]
 	return profile, exists
 }
@@ -159,15 +159,15 @@ func (c *Config) GetCurrentProfile() Profile {
 // ListAllProfiles returns all profiles including the built-in default
 func (c *Config) ListAllProfiles() map[string]Profile {
 	allProfiles := make(map[string]Profile)
-	
+
 	// Add built-in default profile
 	allProfiles["default"] = GetDefaultProfile()
-	
+
 	// Add user-defined profiles
 	for name, profile := range c.Profiles {
 		allProfiles[name] = profile
 	}
-	
+
 	return allProfiles
 }
 
@@ -184,34 +184,32 @@ func (c *Config) DeleteProfile(name string) error {
 	if name == "default" {
 		return fmt.Errorf("cannot delete the built-in default profile")
 	}
-	
+
 	if _, exists := c.Profiles[name]; !exists {
 		return fmt.Errorf("profile '%s' not found", name)
 	}
-	
+
 	delete(c.Profiles, name)
-	
-	// If we deleted the active profile, reset to default
+
+	// Reset active profile if we deleted it
 	if c.DefaultProfile == name {
 		c.DefaultProfile = "default"
 	}
-	
+
 	return nil
 }
 
 // SetDefaultProfile sets the active profile
 func (c *Config) SetDefaultProfile(name string) error {
-	// Allow setting to built-in default
 	if name == "default" {
 		c.DefaultProfile = name
 		return nil
 	}
-	
-	// Check if user-defined profile exists
+
 	if _, exists := c.Profiles[name]; !exists {
 		return fmt.Errorf("profile '%s' not found", name)
 	}
-	
+
 	c.DefaultProfile = name
 	return nil
 }

--- a/internal/cli/oidc/device_flow.go
+++ b/internal/cli/oidc/device_flow.go
@@ -205,7 +205,11 @@ func exchangeDeviceCode(ctx context.Context, cfg FlowConfig, deviceCode string) 
 	case "access_denied":
 		return auth.TokenData{}, retryNone, fmt.Errorf("end user denied the request")
 	default:
-		return auth.TokenData{}, retryNone, fmt.Errorf("token exchange failed: %s", er.ErrorDescription)
+		desc := strings.TrimSpace(er.ErrorDescription)
+		if desc == "" {
+			desc = er.Error
+		}
+		return auth.TokenData{}, retryNone, fmt.Errorf("token exchange failed: %s", desc)
 	}
 }
 

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -51,7 +51,7 @@ var profileCreateCmd = &cobra.Command{
 
 The URL should be the base URL of your Rocketship deployment, e.g.:
   https://rocketship.company.com
-  https://globalbank.rocketship.sh
+  https://cli.rocketship.globalbank.com
 
 TLS settings will be automatically detected from the URL scheme.
 

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.21" // This should be updated with each release
+	DefaultVersion   = "v0.5.22" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request introduces the GitHub Auth Broker as a production-ready authentication service and integrates it into the Rocketship Cloud Helm chart, enabling usage-based deployments with GitHub OAuth support. The broker is now built and released as a standalone binary and container image, and the Helm chart has been updated to deploy and configure the broker alongside the engine when the GitHub mode is enabled. The release workflow and documentation are also updated to reflect these changes. Below are the most important changes grouped by theme:

**Auth Broker Implementation and CI Integration**
* Added a new `.docker/Dockerfile.authbroker` to build the Auth Broker service as a Go binary and container image.
* Updated the release workflow in `.github/workflows/release.yml` to build Auth Broker binaries for all major platforms and to build/push the Auth Broker Docker image. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R56-R62) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R162-R173)
* Included the Auth Broker binary in the embedded binaries build step in the `Makefile`.

**Helm Chart and Deployment Enhancements**
* Added Helm templates for Auth Broker deployment and service (`charts/rocketship/templates/authbroker-deployment.yaml`, `charts/rocketship/templates/authbroker-service.yaml`), plus helper for broker resource naming. [[1]](diffhunk://#diff-59043231e9f4cc281f5660db351ac5618016b3d82e851e02fa767a7668fde057R1-R124) [[2]](diffhunk://#diff-dcbd79b0ece86ea450d94da06caa0ef8395d3644e1fc0b76bec31429b9236e90R1-R23) [[3]](diffhunk://#diff-3db25afc959c300051429b2d1bd673808a644452cf4e23203dbb3b3d8e353a50R47-R50)
* Updated `charts/rocketship/values.yaml` to add configurable broker settings and enable/disable flags, supporting both OIDC and GitHub modes. [[1]](diffhunk://#diff-6bd4f7c3f6bae8ca8c86dfbfa1cec8c720dceb89dcd9f28556f2202f222b9f4eR24-R27) [[2]](diffhunk://#diff-6bd4f7c3f6bae8ca8c86dfbfa1cec8c720dceb89dcd9f28556f2202f222b9f4eR36-R72)
* Created a new usage preset `charts/rocketship/values-github-cloud.yaml` to deploy Rocketship Cloud with the GitHub Auth Broker, including example secrets and ingress configuration.

**Engine Wiring and Broker Integration**
* Modified `charts/rocketship/templates/engine-deployment.yaml` to automatically wire engine environment variables to broker endpoints when `auth.oidc.mode=github`, supporting seamless integration.

**Testing and Validation**
* Enhanced the Helm rendering test script `.github/scripts/helm_template_check.sh` to assert that broker resources and configuration are rendered in the GitHub preset.

**Documentation and Planning Updates**
* Updated `MASTER_PLAN.md` to merge broker implementation and Helm integration into a single PR, clarify broker endpoints, and describe new tests and validation steps. Also, added CLI help text references and streamlined future PR descriptions. [[1]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L26-R45) [[2]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L82-R90) [[3]](diffhunk://#diff-302fa54a9aa5467a60c6be467ed83cf553f877460fd7de26dcc30aa3da66b519L121)