### PR TITLE
(fix): release.yml

### DIFF
--- a/.github/scripts/update_tap.rb
+++ b/.github/scripts/update_tap.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pathname'
+
+FORMULA_TEMPLATE = <<~'FORMULA'
+  class Rocketship < Formula
+    desc "Rocketship CLI"
+    homepage "https://github.com/rocketship-ai/rocketship"
+    version "__VERSION__"
+
+    on_macos do
+      on_arm do
+        url "__URL_DARWIN_ARM64__"
+        sha256 "__SHA_DARWIN_ARM64__"
+      end
+      on_intel do
+        url "__URL_DARWIN_AMD64__"
+        sha256 "__SHA_DARWIN_AMD64__"
+      end
+    end
+
+    on_linux do
+      on_arm do
+        url "__URL_LINUX_ARM64__"
+        sha256 "__SHA_LINUX_ARM64__"
+      end
+      on_intel do
+        url "__URL_LINUX_AMD64__"
+        sha256 "__SHA_LINUX_AMD64__"
+      end
+    end
+
+    def install
+      target = if OS.mac?
+                "rocketship-darwin-#{Hardware::CPU.arm? ? "arm64" : "amd64"}"
+              else
+                "rocketship-linux-#{Hardware::CPU.arm? ? "arm64" : "amd64"}"
+              end
+      bin.install target => "rocketship"
+    end
+
+    test do
+      system "#{bin}/rocketship", "--version"
+    end
+  end
+FORMULA
+
+REQUIRED_ENV = {
+  '__VERSION__' => 'TAG',
+  '__URL_DARWIN_ARM64__' => 'URL_ROCKETSHIP_DARWIN_ARM64',
+  '__SHA_DARWIN_ARM64__' => 'SHA_ROCKETSHIP_DARWIN_ARM64',
+  '__URL_DARWIN_AMD64__' => 'URL_ROCKETSHIP_DARWIN_AMD64',
+  '__SHA_DARWIN_AMD64__' => 'SHA_ROCKETSHIP_DARWIN_AMD64',
+  '__URL_LINUX_ARM64__' => 'URL_ROCKETSHIP_LINUX_ARM64',
+  '__SHA_LINUX_ARM64__' => 'SHA_ROCKETSHIP_LINUX_ARM64',
+  '__URL_LINUX_AMD64__' => 'URL_ROCKETSHIP_LINUX_AMD64',
+  '__SHA_LINUX_AMD64__' => 'SHA_ROCKETSHIP_LINUX_AMD64',
+}.freeze
+
+formula = FORMULA_TEMPLATE.dup
+
+REQUIRED_ENV.each do |placeholder, env_key|
+  value = ENV[env_key]
+  abort "Missing environment variable: #{env_key}" if value.nil? || value.empty?
+  formula.gsub!(placeholder, value)
+end
+
+Pathname.new('Formula').mkpath
+Pathname.new('Formula/rocketship.rb').write(formula)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,11 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout rocketship repo
+        uses: actions/checkout@v4
+        with:
+          path: rocketship
+
       - name: Fetch release assets JSON
         id: rel
         run: |
@@ -213,73 +218,11 @@ jobs:
         with:
           repository: rocketship-ai/homebrew-tap
           token: ${{ secrets.GH_PAT }}
+          path: tap
 
       - name: Update formula
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.rel.outputs.tag }}"
-          cat <<'EOF' > Formula/rocketship.rb
-class Rocketship < Formula
-  desc "Rocketship CLI"
-  homepage "https://github.com/rocketship-ai/rocketship"
-  version "TAG_PLACEHOLDER"
-
-  on_macos do
-    on_arm do
-      url "URL_ROCKETSHIP_DARWIN_ARM64"
-      sha256 "SHA_ROCKETSHIP_DARWIN_ARM64"
-    end
-    on_intel do
-      url "URL_ROCKETSHIP_DARWIN_AMD64"
-      sha256 "SHA_ROCKETSHIP_DARWIN_AMD64"
-    end
-  end
-
-  on_linux do
-    on_arm do
-      url "URL_ROCKETSHIP_LINUX_ARM64"
-      sha256 "SHA_ROCKETSHIP_LINUX_ARM64"
-    end
-    on_intel do
-      url "URL_ROCKETSHIP_LINUX_AMD64"
-      sha256 "SHA_ROCKETSHIP_LINUX_AMD64"
-    end
-  end
-
-  def install
-    target = if OS.mac?
-              "rocketship-darwin-#{Hardware::CPU.arm? ? "arm64" : "amd64"}"
-            else
-              "rocketship-linux-#{Hardware::CPU.arm? ? "arm64" : "amd64"}"
-            end
-    bin.install target => "rocketship"
-  end
-
-  test do
-    system "#{bin}/rocketship", "--version"
-  end
-end
-EOF
-          ruby <<'RUBY'
-require "pathname"
-file = Pathname.new("Formula/rocketship.rb")
-content = file.read
-mapping = {
-  "TAG_PLACEHOLDER" => ENV.fetch("TAG"),
-  "URL_ROCKETSHIP_DARWIN_ARM64" => ENV.fetch("URL_ROCKETSHIP_DARWIN_ARM64"),
-  "SHA_ROCKETSHIP_DARWIN_ARM64" => ENV.fetch("SHA_ROCKETSHIP_DARWIN_ARM64"),
-  "URL_ROCKETSHIP_DARWIN_AMD64" => ENV.fetch("URL_ROCKETSHIP_DARWIN_AMD64"),
-  "SHA_ROCKETSHIP_DARWIN_AMD64" => ENV.fetch("SHA_ROCKETSHIP_DARWIN_AMD64"),
-  "URL_ROCKETSHIP_LINUX_ARM64" => ENV.fetch("URL_ROCKETSHIP_LINUX_ARM64"),
-  "SHA_ROCKETSHIP_LINUX_ARM64" => ENV.fetch("SHA_ROCKETSHIP_LINUX_ARM64"),
-  "URL_ROCKETSHIP_LINUX_AMD64" => ENV.fetch("URL_ROCKETSHIP_LINUX_AMD64"),
-  "SHA_ROCKETSHIP_LINUX_AMD64" => ENV.fetch("SHA_ROCKETSHIP_LINUX_AMD64"),
-}
-mapping.each do |marker, value|
-  content = content.gsub(marker, value)
-end
-file.write(content)
-RUBY
+        working-directory: tap
+        run: ruby ../rocketship/.github/scripts/update_tap.rb
         env:
           TAG: ${{ steps.rel.outputs.tag }}
           URL_ROCKETSHIP_DARWIN_ARM64: ${{ steps.rel.outputs.url_rocketship_darwin_arm64 }}
@@ -292,6 +235,7 @@ RUBY
           SHA_ROCKETSHIP_LINUX_AMD64: ${{ steps.rel.outputs.sha_rocketship_linux_amd64 }}
 
       - name: Commit and open PR
+        working-directory: tap
         run: |
           set -euo pipefail
           git config user.name "rocketship-release-bot"


### PR DESCRIPTION
This pull request refactors the process for updating the Homebrew tap formula during releases. The main change is moving the formula generation and update logic from inline shell and Ruby scripting in the GitHub Actions workflow to a dedicated, reusable Ruby script. This improves maintainability and reduces complexity in the workflow file.

Key changes:

**Homebrew Formula Update Refactor:**
* Added a new script at `.github/scripts/update_tap.rb` that generates the Homebrew formula for the Rocketship CLI. This script uses environment variables for all version and asset values, and writes the output to `Formula/rocketship.rb`.
* Updated the workflow (`.github/workflows/release.yml`) to use the new script instead of inline shell/Ruby blocks. The workflow now checks out both the main repository and the homebrew-tap repo, and calls the script from the correct working directory. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R190-R194) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R221-R225)
* The formula update step now uses the `working-directory: tap` directive, ensuring the formula is written to the correct location in the tap repository.
* The commit and PR step also now runs from the `tap` directory for consistency.