### PR TITLE
Pipeline to open PR on RS Cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v4
 
@@ -181,6 +183,81 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           curl -X POST "https://proxy.golang.org/github.com/rocketship-ai/rocketship/@v/${VERSION}.info" || true
+
+  sync-internal-chart:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      GH_PAT: ${{ secrets.GH_PAT }}
+    steps:
+
+      - name: GH_PAT not configured
+        if: env.GH_PAT == ''
+        run: echo "GH_PAT secret not configured; skipping internal chart sync."
+
+      - name: Skip when GH_PAT missing
+        if: env.GH_PAT == ''
+        run: exit 0
+
+      - name: Checkout public repository
+        uses: actions/checkout@v4
+
+      - name: Checkout internal charts repo
+        uses: actions/checkout@v4
+        with:
+          repository: rocketship-ai/rocketship-internal
+          token: ${{ env.GH_PAT }}
+          path: internal
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Update image tags in internal chart
+        id: update
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd internal
+
+          update_file() {
+            local file="$1"
+            if [ -f "$file" ]; then
+              yq -i '.engine.image.tag = strenv(VERSION)' "$file"
+              yq -i '.worker.image.tag = strenv(VERSION)' "$file"
+              yq -i '.auth.broker.image.tag = strenv(VERSION)' "$file"
+            fi
+          }
+
+          update_file charts/rocketship/values-production.yaml
+          update_file charts/rocketship/values-github-cloud.yaml
+          update_file charts/rocketship/values-github-web.yaml
+
+          if git status --porcelain | grep . >/dev/null; then
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR in internal repo
+        if: steps.update.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ env.GH_PAT }}
+          path: internal
+          commit-message: "chore: bump rocketship images to ${{ needs.release.outputs.version }}"
+          branch: bump/${{ needs.release.outputs.version }}
+          delete-branch: true
+          title: "Bump Rocketship images to ${{ needs.release.outputs.version }}"
+          body: |
+            Automated update created from the public release pipeline.
+            - engine/worker/auth-broker image tags set to `${{ needs.release.outputs.version }}`.
+
+      - name: No changes detected
+        if: steps.update.outputs.changes != 'true'
+        run: echo "Internal chart already up to date; no PR created."
 
   update-homebrew-tap:
     needs: release

--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.23" // This should be updated with each release
+	DefaultVersion   = "v0.5.24" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request updates the release workflow to automate syncing image tags in an internal Helm chart repository whenever a new release is published. It introduces a new workflow job that checks out both the public and internal repositories, updates image tags, and creates a pull request in the internal repo if changes are detected.

**Workflow automation improvements:**

* Added a new `sync-internal-chart` job to `.github/workflows/release.yml` that runs after the release, checks out the internal charts repository, updates image tags in multiple values files using `yq`, and creates a pull request if any changes are detected. This ensures that the internal Helm charts always reference the latest released images.

**Workflow outputs:**

* The `release` job now outputs the released version, making it available to downstream jobs such as `sync-internal-chart`.