### PR TITLE
only update charts/rocketship/values-production.yaml file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,8 +232,6 @@ jobs:
           }
 
           update_file charts/rocketship/values-production.yaml
-          update_file charts/rocketship/values-github-cloud.yaml
-          update_file charts/rocketship/values-github-web.yaml
 
           if git status --porcelain | grep . >/dev/null; then
             echo "changes=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This pull request makes a small change to the release workflow by removing updates to two configuration files during the release process. Only the update to `charts/rocketship/values-production.yaml` remains.

- Removed steps that updated `charts/rocketship/values-github-cloud.yaml` and `charts/rocketship/values-github-web.yaml` from the release workflow.