### PR TITLE
Exit 1 Now When There is a Rocketship Run Command Failure

### DIFF
--- a/internal/embedded/binaries.go
+++ b/internal/embedded/binaries.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	githubReleaseURL = "https://github.com/rocketship-ai/rocketship/releases/download/%s/%s"
-	DefaultVersion   = "v0.5.28" // This should be updated with each release
+	DefaultVersion   = "v0.5.29" // This should be updated with each release
 )
 
 type binaryMetadata struct {


### PR DESCRIPTION
This pull request refactors the test suite summary reporting in the CLI and improves error handling for test runs. The main change is the introduction of a new `testSummary` struct and helper function to aggregate test results, which simplifies the code and makes error handling more robust. Additionally, the default binary version is updated.

**Test summary aggregation and reporting:**
* Added a new `testSummary` struct and a `summarizeResults` function in `internal/cli/run.go` to encapsulate aggregation logic for test suite and test results, replacing manual aggregation in `printFinalSummary`.
* Refactored `printFinalSummary` to accept a `testSummary` object and updated its usage in `NewRunCmd` to use the new summary aggregation. [[1]](diffhunk://#diff-30f30550c03f971732cfeb7b92d7d64e64447acf969bfa5a55832429cf18cd01L274-R316) [[2]](diffhunk://#diff-30f30550c03f971732cfeb7b92d7d64e64447acf969bfa5a55832429cf18cd01L553-R574)

**Error handling improvements:**
* Added error returns in `NewRunCmd` to handle cases where no test suites are executed or when any suites fail, improving feedback for failed or empty test runs.

**Version update:**
* Updated the default binary version from `v0.5.28` to `v0.5.29` in `internal/embedded/binaries.go`.