### PR TITLE
Fix misleading .gitignore comment and add Python cache entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@ mcp-server/npm-debug.log*
 mcp-server/yarn-debug.log*
 mcp-server/yarn-error.log*
 
-# python
+# macOS
 .DS_Store
 **/.DS_Store
+
+# Python virtual environments
+__pycache__/
+*.pyc
 
 # documentation build artifacts
 docs/site/


### PR DESCRIPTION
## Summary
- Fixes the `# python` comment that was incorrectly labeling `.DS_Store` entries (a macOS artifact, not Python-related)
- Adds missing `__pycache__/` and `*.pyc` entries since the project has Python-based plugins (playwright, browser_use, agent)

## Test plan
- [x] All lints and tests pass
- [x] No functional changes, only .gitignore cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)